### PR TITLE
ci: ignore parallel jobs testing

### DIFF
--- a/protocols/dfns-cggmp21/tests/ecdsa.rs
+++ b/protocols/dfns-cggmp21/tests/ecdsa.rs
@@ -42,6 +42,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "takes a long time to work on CI"]
     async fn test_externalities_parallel_jobs() {
         test_utils::setup_log();
         const N: usize = 3;

--- a/protocols/mp-ecdsa/tests/ecdsa.rs
+++ b/protocols/mp-ecdsa/tests/ecdsa.rs
@@ -42,6 +42,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "takes a long time to work on CI"]
     async fn test_externalities_parallel_jobs() {
         test_utils::setup_log();
         const N: usize = 3;


### PR DESCRIPTION
CI has very limited resources, we do not want to test these tests on CI.