### PR TITLE
feat: Rework Gadget Shell CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,6 +4102,7 @@ dependencies = [
  "hex",
  "libp2p 0.53.2",
  "parity-scale-codec 3.6.9",
+ "rand 0.8.5",
  "sc-keystore",
  "scale-info",
  "serde",

--- a/shell-configs/local-testnet-0.toml
+++ b/shell-configs/local-testnet-0.toml
@@ -3,4 +3,5 @@ bind_port = 30555
 bootnodes = []
 # 12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN
 node_key = "0000000000000000000000000000000000000000000000000000000000000000"
-keystore_path = "../tangle/tmp/alice/chains/local_testnet/keystore"
+chain = "local_testnet"
+base_path = "../tangle/tmp/alice"

--- a/shell-configs/local-testnet-1.toml
+++ b/shell-configs/local-testnet-1.toml
@@ -3,4 +3,5 @@ bind_port = 30556
 bootnodes = []
 # 12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
 node_key = "0000000000000000000000000000000000000000000000000000000000000001"
-keystore_path = "../tangle/tmp/bob/chains/local_testnet/keystore"
+chain = "local_testnet"
+base_path = "../tangle/tmp/bob"

--- a/shell-configs/local-testnet-2.toml
+++ b/shell-configs/local-testnet-2.toml
@@ -3,4 +3,5 @@ bind_port = 30557
 bootnodes = []
 # 12D3KooWHdiAxVd8uMQR1hGWXccidmfCwLqcMpGwR6QcTP6QRMuD
 node_key = "0000000000000000000000000000000000000000000000000000000000000002"
-keystore_path = "../tangle/tmp/charlie/chains/local_testnet/keystore"
+chain = "local_testnet"
+base_path = "../tangle/tmp/charlie"

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -32,6 +32,7 @@ parity-scale-codec = { workspace = true }
 structopt = "0.3.26"
 toml = "0.8.11"
 serde = { workspace = true }
+rand = { workspace = true }
 hex = { workspace = true }
 sha2 = "0.10.8"
 futures = { workspace = true }
@@ -54,10 +55,10 @@ features = [
   "cbor",
   "identify",
   "kad",
-    "dcutr",
-    "relay",
-    "ping",
-    "dns"
+  "dcutr",
+  "relay",
+  "ping",
+  "dns"
 ]
 
 [dev-dependencies]

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -7,7 +7,7 @@ pub struct ShellConfig {
     pub base_path: PathBuf,
     pub keystore: KeystoreConfig,
     pub subxt: SubxtConfig,
-    pub bind_ip: std::net::Ipv4Addr,
+    pub bind_ip: std::net::IpAddr,
     pub bind_port: u16,
     pub bootnodes: Vec<Multiaddr>,
     pub node_key: [u8; 32],

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -4,9 +4,10 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct ShellConfig {
+    pub base_path: PathBuf,
     pub keystore: KeystoreConfig,
     pub subxt: SubxtConfig,
-    pub bind_ip: String,
+    pub bind_ip: std::net::Ipv4Addr,
     pub bind_port: u16,
     pub bootnodes: Vec<Multiaddr>,
     pub node_key: [u8; 32],

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -1,7 +1,7 @@
 use color_eyre::Result;
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{fmt::Display, net::Ipv4Addr, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
 mod config;
@@ -17,23 +17,79 @@ mod tangle;
     about = "An MPC executor that connects to the Tangle network to perform work"
 )]
 struct Opt {
-    /// Input file
-    #[structopt(parse(from_os_str), short = "c", long = "config")]
-    config: PathBuf,
-    #[structopt(long, short = "v", parse(from_occurrences))]
+    /// The path to the configuration file. If not provided, the default configuration will be used.
+    /// Note that if the configuration file is provided, the command line arguments will be ignored.
+    #[structopt(global = true, parse(from_os_str), short = "c", long = "config")]
+    config: Option<PathBuf>,
+    /// The verbosity level, can be used multiple times
+    #[structopt(long, short = "v", global = true, parse(from_occurrences))]
     verbose: i32,
-    #[structopt(long)]
+    /// Whether to use pretty logging
+    #[structopt(global = true, long)]
     pretty: bool,
+    /// The options for the shell
+    #[structopt(flatten)]
+    options: TomlConfig,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Debug, StructOpt, Serialize, Deserialize)]
+#[structopt(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+enum SupportedChains {
+    #[default]
+    LocalTestnet,
+    LocalMainnet,
+    Testnet,
+    Mainnet,
+}
+
+#[derive(Debug, StructOpt, Serialize, Deserialize)]
 struct TomlConfig {
-    bind_ip: String,
+    /// The IP address to bind to for the libp2p node.
+    #[structopt(long = "bind-ip", short = "i", default_value = defaults::BIND_IP)]
+    #[serde(default = "defaults::bind_ip")]
+    bind_ip: Ipv4Addr,
+    /// The port to bind to for the libp2p node.
+    #[structopt(long = "port", short = "p", default_value = defaults::BIND_PORT)]
+    #[serde(default = "defaults::bind_port")]
     bind_port: u16,
-    bootnodes: Vec<String>,
-    /// The node key in hex format
-    node_key: String,
-    keystore_path: String,
+    /// The RPC URL of the Tangle Node.
+    #[structopt(long = "url", parse(try_from_str = url::Url::parse), default_value = defaults::RPC_URL)]
+    #[serde(default = "defaults::rpc_url")]
+    url: url::Url,
+    /// The List of bootnodes to connect to
+    #[structopt(long = "bootnodes", parse(try_from_str = <Multiaddr as std::str::FromStr>::from_str))]
+    #[serde(default)]
+    bootnodes: Vec<Multiaddr>,
+    /// The node key in hex format. If not provided, a random node key will be generated.
+    #[structopt(long = "node-key", env, parse(try_from_str = parse_node_key))]
+    #[serde(skip_serializing)]
+    node_key: Option<String>,
+    /// The base path to store the shell data, and read data from the keystore.
+    #[structopt(
+        parse(from_os_str),
+        long,
+        short = "d",
+        required_unless = "config",
+        default_value_if("config", None, ".")
+    )]
+    base_path: PathBuf,
+    /// Keystore Password, if not provided, the password will be read from the environment variable.
+    #[structopt(long = "keystore-password", env)]
+    keystore_password: Option<String>,
+    /// The chain to connect to, must be one of the supported chains.
+    #[structopt(
+        long,
+        default_value,
+        possible_values = &[
+            "local_testnet",
+            "local_mainnet",
+            "testnet",
+            "mainnet"
+        ]
+    )]
+    #[serde(default)]
+    chain: SupportedChains,
 }
 
 #[tokio::main]
@@ -41,38 +97,37 @@ async fn main() -> Result<()> {
     color_eyre::install()?;
     let opt = Opt::from_args();
     setup_logger(&opt, "gadget_shell")?;
-    let config_contents = std::fs::read_to_string(opt.config)?;
-    let config: TomlConfig = toml::from_str(&config_contents)?;
-    /*
-    // Hardcoded paths for now.
-    let keystore_path = std::path::PathBuf::from(format!(
-        "{}../../target/tangle/chains/local_testnet/keystore",
-        env!("CARGO_MANIFEST_DIR")
-    ));*/
-    let keystore_path = std::path::PathBuf::from(config.keystore_path);
-
-    let mut bootnodes = vec![];
-    for bootnode in config.bootnodes.iter() {
-        let addr: Multiaddr = bootnode.parse()?;
-        bootnodes.push(addr);
-    }
-
-    let decoded_node_key = hex::decode(config.node_key)
-        .map_err(|e| color_eyre::eyre::eyre!("Failed to parse node key: {e}"))?;
-
+    let config = if let Some(config) = opt.config {
+        let config_contents = std::fs::read_to_string(config)?;
+        toml::from_str(&config_contents)?
+    } else {
+        opt.options
+    };
     shell::run_forever(config::ShellConfig {
         keystore: config::KeystoreConfig::Path {
-            path: keystore_path,
-            password: None,
+            path: config
+                .base_path
+                .join("chains")
+                .join(config.chain.to_string())
+                .join("keystore"),
+            password: config.keystore_password.map(|s| s.into()),
         },
         subxt: config::SubxtConfig {
-            endpoint: url::Url::parse("ws://127.0.0.1:9944")?,
+            endpoint: config.url,
         },
+        base_path: config.base_path,
         bind_ip: config.bind_ip,
         bind_port: config.bind_port,
-        bootnodes,
-        node_key: <[u8; 32]>::try_from(decoded_node_key.as_slice())
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to parse node key: {e}"))?,
+        bootnodes: config.bootnodes,
+        node_key: hex::decode(
+            config
+                .node_key
+                .unwrap_or_else(|| hex::encode(defaults::generate_node_key())),
+        )?
+        .try_into()
+        .map_err(|_| {
+            color_eyre::eyre::eyre!("Invalid node key length, expect 32 bytes hex string")
+        })?,
     })
     .await?;
     Ok(())
@@ -104,4 +159,64 @@ fn setup_logger(opt: &Opt, filter: &str) -> Result<()> {
         logger.compact().init();
     }
     Ok(())
+}
+
+mod defaults {
+    pub const BIND_PORT: &str = "30555";
+    pub const BIND_IP: &str = "0.0.0.0";
+    pub const RPC_URL: &str = "ws://127.0.0.1:9944";
+
+    pub fn rpc_url() -> url::Url {
+        url::Url::parse(RPC_URL).expect("Default RPC URL is valid")
+    }
+
+    pub fn bind_ip() -> std::net::Ipv4Addr {
+        BIND_IP.parse().expect("Default bind IP is valid")
+    }
+
+    pub fn bind_port() -> u16 {
+        BIND_PORT.parse().expect("Default bind port is valid")
+    }
+
+    /// Generates a random node key
+    pub fn generate_node_key() -> [u8; 32] {
+        use rand::Rng;
+
+        let mut rng = rand::thread_rng();
+        let mut array = [0u8; 32];
+        rng.fill(&mut array);
+        array
+    }
+}
+
+fn parse_node_key(s: &str) -> Result<String> {
+    let result: [u8; 32] = hex::decode(s.replace("0x", ""))?.try_into().map_err(|_| {
+        color_eyre::eyre::eyre!("Invalid node key length, expect 32 bytes hex string")
+    })?;
+    Ok(hex::encode(result))
+}
+
+impl FromStr for SupportedChains {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "local_testnet" => Ok(SupportedChains::LocalTestnet),
+            "local_mainnet" => Ok(SupportedChains::LocalMainnet),
+            "testnet" => Ok(SupportedChains::Testnet),
+            "mainnet" => Ok(SupportedChains::Mainnet),
+            _ => Err(format!("Invalid chain: {}", s)),
+        }
+    }
+}
+
+impl Display for SupportedChains {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SupportedChains::LocalTestnet => write!(f, "local_testnet"),
+            SupportedChains::LocalMainnet => write!(f, "local_mainnet"),
+            SupportedChains::Testnet => write!(f, "testnet"),
+            SupportedChains::Mainnet => write!(f, "mainnet"),
+        }
+    }
 }

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -1,7 +1,7 @@
 use color_eyre::Result;
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, net::Ipv4Addr, path::PathBuf, str::FromStr};
+use std::{fmt::Display, net::IpAddr, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
 mod config;
@@ -48,7 +48,7 @@ struct TomlConfig {
     /// The IP address to bind to for the libp2p node.
     #[structopt(long = "bind-ip", short = "i", default_value = defaults::BIND_IP)]
     #[serde(default = "defaults::bind_ip")]
-    bind_ip: Ipv4Addr,
+    bind_ip: IpAddr,
     /// The port to bind to for the libp2p node.
     #[structopt(long = "port", short = "p", default_value = defaults::BIND_PORT)]
     #[serde(default = "defaults::bind_port")]
@@ -170,7 +170,7 @@ mod defaults {
         url::Url::parse(RPC_URL).expect("Default RPC URL is valid")
     }
 
-    pub fn bind_ip() -> std::net::Ipv4Addr {
+    pub fn bind_ip() -> std::net::IpAddr {
         BIND_IP.parse().expect("Default bind IP is valid")
     }
 

--- a/shell/src/network/gossip.rs
+++ b/shell/src/network/gossip.rs
@@ -428,9 +428,10 @@ mod tests {
                 subxt: SubxtConfig {
                     endpoint: url::Url::from_directory_path("/").unwrap(),
                 },
-                bind_ip: "0.0.0.0".to_string(),
+                bind_ip: "0.0.0.0".parse().unwrap(),
                 bind_port,
                 bootnodes,
+                base_path: std::path::PathBuf::new(),
                 node_key: [0u8; 32],
             };
 


### PR DESCRIPTION
This PR Imporves the gadget shell CLI to make it easier to work with, with sensible defaults.

```bash
Gadget 0.1.0
An MPC executor that connects to the Tangle network to perform work

USAGE:
    gadget-shell [FLAGS] [OPTIONS] --base-path <base-path>

FLAGS:
    -h, --help       Prints help information
        --pretty     Whether to use pretty logging
    -V, --version    Prints version information
    -v, --verbose    The verbosity level, can be used multiple times

OPTIONS:
    -d, --base-path <base-path>
            The base path to store the shell data, and read data from the keystore

    -i, --bind-ip <bind-ip>                        The IP address to bind to for the libp2p node [default: 0.0.0.0]
    -p, --port <bind-port>                         The port to bind to for the libp2p node [default: 30555]
        --bootnodes <bootnodes>...                 The List of bootnodes to connect to
        --chain <chain>
            The chain to connect to, must be one of the supported chains [default: local_testnet]  [possible values:
            local_testnet, local_mainnet, testnet, mainnet]
    -c, --config <config>
            The path to the configuration file. If not provided, the default configuration will be used. Note that if
            the configuration file is provided, the command line arguments will be ignored
        --keystore-password <keystore-password>
            Keystore Password, if not provided, the password will be read from the environment variable [env:
            KEYSTORE_PASSWORD=]
        --node-key <node-key>
            The node key in hex format. If not provided, a random node key will be generated [env: NODE_KEY=]

        --url <url>                                The RPC URL of the Tangle Node [default: ws://127.0.0.1:9944]
```