### PR TITLE
Disable ZkSaaS Pipeline + Metrics wrapper for jobs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [target.aarch64-apple-darwin]
 linker = "clang++"
+
+[build]
+# For access to tokio metrics
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -54,7 +54,7 @@ jobs:
         run: sudo apt-get install protobuf-compiler
 
       - name: Run Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --tests -- -D warnings
 
   build:
     timeout-minutes: 120

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -99,7 +99,6 @@ jobs:
             package: [
               gadget-core,
               gadget-common,
-              zk-saas-protocol,
               dfns-cggmp21-protocol,
               threshold-bls-protocol,
               zcash-frost-protocol,
@@ -130,5 +129,4 @@ jobs:
         run: cargo install cargo-nextest --locked
 
       - name: tests
-        if: ${{ matrix.package != 'zk-saas-protocol' }}
         run: cargo nextest run --release --nocapture --package ${{ matrix.package }}

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -106,6 +106,9 @@ jobs:
               silent-shard-dkls23-ll-protocol,
             ]
     steps:
+      - name: Skip zk-saas-protocol
+        if: ${{ matrix.package == 'zk-saas-protocol' }}
+        run: exit 0
       - name: checkout code
         uses: actions/checkout@v2
 

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -91,9 +91,9 @@ jobs:
         run: cargo build --workspace --package ${{ matrix.package }}
 
   testing:
-    timeout-minutes: 120
+    timeout-minutes: 90
     name: cargo test
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
         matrix:
             package: [
@@ -119,7 +119,12 @@ jobs:
           cache-on-failure: "true"
 
       - name: install protobuf
-        run: brew install protobuf
+        run: brew install protobuf gmp
+
+      - name: Set Relevant M1 env vars
+        run: |
+          export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/lib
+          export INCLUDE_PATH=$INCLUDE_PATH:/opt/homebrew/include
 
       - name: install cargo-nextest
         run: cargo install cargo-nextest --locked

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -106,9 +106,6 @@ jobs:
               silent-shard-dkls23-ll-protocol,
             ]
     steps:
-      - name: Skip zk-saas-protocol
-        if: ${{ matrix.package == 'zk-saas-protocol' }}
-        run: exit 0
       - name: checkout code
         uses: actions/checkout@v2
 
@@ -135,7 +132,3 @@ jobs:
       - name: tests
         if: ${{ matrix.package != 'zk-saas-protocol' }}
         run: cargo nextest run --release --nocapture --package ${{ matrix.package }}
-
-      - name: tests (parallel enabled)
-        if: ${{ matrix.package == 'zk-saas-protocol' }}
-        run: cargo nextest run --features=parallel --release --nocapture --package ${{ matrix.package }}

--- a/common/src/prometheus.rs
+++ b/common/src/prometheus.rs
@@ -27,11 +27,9 @@ lazy_static! {
             .expect("metric can be created");
     pub static ref TOKIO_ACTIVE_TASKS: Gauge =
         Gauge::new("tokio_tasks", "Number of active tasks").expect("metric can be created");
-    pub static ref JOB_RUN_TIME: Histogram = Histogram::with_opts(
-        HistogramOpts::new("job_runtime", "Job Runtime (s)")
-            .variable_labels(vec!["Seconds".to_string()])
-    )
-    .expect("metric can be created");
+    pub static ref JOB_RUN_TIME: Histogram =
+        Histogram::with_opts(HistogramOpts::new("job_runtime", "Job Runtime (s)"))
+            .expect("metric can be created");
 }
 
 #[derive(Debug, Clone)]

--- a/common/src/prometheus.rs
+++ b/common/src/prometheus.rs
@@ -2,7 +2,9 @@ use lazy_static::lazy_static;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
-use substrate_prometheus_endpoint::prometheus::{IntCounter, Registry};
+use substrate_prometheus_endpoint::prometheus::{
+    Gauge, Histogram, HistogramOpts, IntCounter, Registry,
+};
 
 lazy_static! {
     pub static ref REGISTRY: Registry = Registry::new();
@@ -10,6 +12,26 @@ lazy_static! {
         IntCounter::new("bytes_received", "Bytes Received").expect("metric can be created");
     pub static ref BYTES_SENT: IntCounter =
         IntCounter::new("bytes_sent", "Bytes Sent").expect("metric can be created");
+    pub static ref JOBS_RUNNING: Gauge =
+        Gauge::new("jobs_running", "Jobs Running").expect("metric can be created");
+    pub static ref JOBS_STARTED: IntCounter =
+        IntCounter::new("jobs_started", "Jobs Started").expect("metric can be created");
+    pub static ref JOBS_COMPLETED: IntCounter =
+        IntCounter::new("jobs_completed", "Completed jobs (agnostic to success)")
+            .expect("metric can be created");
+    pub static ref JOBS_COMPLETED_SUCCESS: IntCounter =
+        IntCounter::new("jobs_completed_success", "Successfully completed jobs")
+            .expect("metric can be created");
+    pub static ref JOBS_COMPLETED_FAILED: IntCounter =
+        IntCounter::new("jobs_completed_failed", "Unsuccessfully completed jobs")
+            .expect("metric can be created");
+    pub static ref TOKIO_ACTIVE_TASKS: Gauge =
+        Gauge::new("tokio_tasks", "Number of active tasks").expect("metric can be created");
+    pub static ref JOB_RUN_TIME: Histogram = Histogram::with_opts(
+        HistogramOpts::new("job_runtime", "Job Runtime (s)")
+            .variable_labels(vec!["Seconds".to_string()])
+    )
+    .expect("metric can be created");
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
We will need to run the ZkSaaS protocol in a beefier machine. The GitHub runners are too slow for it to reliably pass.