### PR TITLE
Remove unnecessary WASM dependencies from `core`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,14 +24,5 @@ sp-core = { workspace = true }
 futures-timer = "3.0.3"
 serde = { workspace = true, features = ["derive"] }
 
-[target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen-test = "0.3.34"
-getrandom = { workspace = true, features = ["js"] }
-wasm-bindgen-futures = "0.4.42"
-sp-core = { workspace = true }
-
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }
-
-[target.'cfg(target_family = "wasm")'.dev-dependencies]
-wasm-bindgen-test = "0.3.34"

--- a/core/src/job_manager.rs
+++ b/core/src/job_manager.rs
@@ -10,11 +10,6 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(target_family = "wasm")]
-use wasm_bindgen_test::*;
-#[cfg(target_family = "wasm")]
-wasm_bindgen_test_configure!(run_in_browser);
-
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PollMethod {
     Interval { millis: u64 },


### PR DESCRIPTION
No WASM tests exist, `wasm_bindgen_test` is being setup unnecessarily.