### PR TITLE
Rename Gadget CLI to Tangle CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo-gadget"
+name = "cargo-tangle"
 version = "0.1.0"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Fixes #225

Rename the Gadget CLI to Tangle CLI and update subcommands.

* **cli/Cargo.toml**
  - Rename the package from `cargo-gadget` to `cargo-tangle`.

* **cli/src/main.rs**
  - Update the `bin_name` attribute in the `clap` macro to `cargo-tangle`.
  - Add a new subcommand `Gadget` to the `Commands` enum.
  - Move the `Create` and `Deploy` subcommands under the `Gadget` subcommand.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/webb-tools/gadget/issues/225?shareId=8cf7fdf9-26dc-4155-bd46-0a5505d9330d).