### PR TITLE
Add CLI usage documentation to README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,76 @@
+# Tangle CLI
+
+Create and Deploy blueprints on Tangle Network.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Installation](#installation)
+3. [Creating a New Blueprint/Gadget](#creating-a-new-blueprintgadget)
+4. [Deploying the Blueprint to a Local Tangle Node](#deploying-the-blueprint-to-a-local-tangle-node)
+5. [Required Environment Variables for Deployment](#required-environment-variables-for-deployment)
+6. [Examples](#examples)
+
+## Overview
+
+The Tangle CLI is a command-line tool that allows you to create and deploy blueprints/gadgets on the Tangle network. It provides a simple and efficient way to manage your blueprints and gadgets, making it easy to get started with Tangle Blueprints.
+
+## Installation
+
+To install the Tangle CLI from crates.io, run the following command:
+
+```bash
+cargo install cargo-tangle
+```
+
+## Creating a New Blueprint/Gadget
+
+To create a new blueprint/gadget using the Tangle CLI, use the following command:
+
+```bash
+cargo tangle gadget create --name <blueprint_name>
+```
+
+Replace `<blueprint_name>` with the desired name for your blueprint/gadget.
+
+### Example
+
+```bash
+cargo tangle gadget create --name my_blueprint
+```
+
+## Deploying the Blueprint to a Local Tangle Node
+
+To deploy the blueprint to a local Tangle node, use the following command:
+
+```bash
+cargo tangle gadget deploy --rpc-url <rpc_url> --package <package_name>
+```
+
+Replace `<rpc_url>` with the RPC URL of your local Tangle node and `<package_name>` with the name of the package to deploy.
+
+### Example
+
+```bash
+cargo tangle gadget deploy --rpc-url ws://localhost:9944 --package my_blueprint
+```
+
+Expected output:
+
+```
+Blueprint #0 created successfully by 5F3sa2TJAWMqDhXG6jhV4N8ko9rUjC2q7z6z5V5s5V5s5V5s with extrinsic hash: 0x1234567890abcdef
+```
+
+## Required Environment Variables for Deployment
+
+The following environment variables are required for deploying the blueprint:
+
+- `SIGNER`: The SURI of the signer account.
+- `EVM_SIGNER`: The SURI of the EVM signer account.
+
+### Example
+
+```bash
+export SIGNER="//Alice"
+export EVM_SIGNER="0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+```


### PR DESCRIPTION
Fixes #226

Add documentation for the Tangle CLI usage in the `cli/README.md` file.

* **Overview**: Add an overview section at the top of the `README.md` file.
* **Table of Contents**: Add an index at the top of the `README.md` file.
* **Installation**: Document how to install the CLI from crates.io.
* **Creating a New Blueprint/Gadget**: Document how to use the CLI to create a new blueprint/gadget.
* **Deploying the Blueprint**: Document how to use the CLI to deploy the blueprint to a local Tangle node.
* **Required Environment Variables**: Document the required ENVs for the deployment.
* **Examples**: Provide examples with each step and the expected output.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/webb-tools/gadget/issues/226?shareId=9f91db3a-8a8b-4bdc-ab1b-8d781ac217c0).