### PR TITLE
Cleanup unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,16 +2246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,9 +4264,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "cfg-if",
- "color-eyre",
  "futures",
- "futures-util",
  "gadget-core",
  "gadget-io",
  "getrandom",
@@ -4299,9 +4287,6 @@ dependencies = [
  "subxt-signer",
  "tangle-subxt",
  "thiserror 1.0.61",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -4310,7 +4295,6 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "auto_impl",
- "futures",
  "futures-timer",
  "gadget-io",
  "hex",
@@ -4342,7 +4326,6 @@ dependencies = [
  "hex",
  "js-sys",
  "multiaddr",
- "p256",
  "parity-scale-codec 3.6.12",
  "sc-keystore",
  "scale-info",
@@ -4395,11 +4378,7 @@ dependencies = [
  "thiserror 1.0.61",
  "tokio",
  "tracing",
- "tracing-log 0.2.0",
- "tracing-subscriber 0.3.18",
- "tracing-wasm",
  "w3f-bls",
- "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -6830,16 +6809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minicov"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169"
-dependencies = [
- "cc",
- "walkdir",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7372,18 +7341,6 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.8",
-]
 
 [[package]]
 name = "pallet-authorship"
@@ -7978,15 +7935,6 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.75",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -9357,12 +9305,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -12353,17 +12295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-wasm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
-dependencies = [
- "tracing",
- "tracing-subscriber 0.3.18",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "trie-db"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12821,32 +12752,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
-dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "minicov",
- "scoped-tls",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.75",
-]
 
 [[package]]
 name = "wasm-instrument"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,16 +18,12 @@ auto_impl = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
-futures-util = { workspace = true }
 hex = { workspace = true }
 futures = { workspace = true }
 round-based = { workspace = true, features = ["derive"] }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"], optional = true }
 lazy_static = { workspace = true }
-getrandom = { workspace = true }
-tracing = { workspace = true, default-features = false }
-tracing-subscriber = { workspace = true, default-features = false }
-tracing-core = { workspace = true, default-features = false }
+thiserror = { workspace = true }
 
 # Substrate
 tangle-subxt = { workspace = true, optional = true }
@@ -37,9 +33,7 @@ sp-io = { workspace = true, features = ["disable_allocator", "disable_panic_hand
 sp-core = { workspace = true, features = ["full_crypto"] }
 sp-runtime = { workspace = true, features = ["serde"] }
 substrate-prometheus-endpoint = { workspace = true, optional = true }
-
 parity-scale-codec = { workspace = true, optional = true }
-thiserror = { workspace = true }
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -49,27 +43,25 @@ default = ["substrate", "std", "tangle-testnet", "subxt/native"]
 tangle-testnet = []
 tangle-mainnet = []
 substrate = [
-  "gadget-core/substrate",
-  "tangle-subxt",
-  "subxt-signer",
-  "subxt/jsonrpsee",
-  "substrate-prometheus-endpoint",
-  "parity-scale-codec",
+    "dep:parity-scale-codec",
+    "dep:tangle-subxt",
+    "dep:substrate-prometheus-endpoint",
+    "dep:subxt-signer",
+    "dep:subxt",
+    "gadget-core/substrate",
+    "subxt/jsonrpsee",
 ]
 std = [
-  "gadget-io/std",
-  "gadget-core/std",
-  "dep:sqlx",
-  "serde/std",
-  "tracing/std",
-  "tracing/attributes",
-  "sp-io/std",
-  "sp-runtime/std",
+    "dep:sqlx",
+    "gadget-io/std",
+    "gadget-core/std",
+    "serde/std",
+    "sp-io/std",
+    "sp-runtime/std",
 ]
 wasm = [
-    "subxt-signer/web",
-    "subxt/web",
-    "subxt/jsonrpsee",
-    "parity-scale-codec",
+    "subxt-signer?/web",
+    "subxt?/web",
+    "subxt?/jsonrpsee",
 ]
 testing = []

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,33 +7,33 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
+auto_impl = { workspace = true }
 cfg-if = { workspace = true }
-libsecp256k1 = { workspace = true }
+futures = { workspace = true }
 gadget-core = { workspace = true }
 gadget-io = { workspace = true }
-serde = { workspace = true, features = ["derive", "alloc"] }
-serde_json = { workspace = true }
-prometheus = { workspace = true }
-auto_impl = { workspace = true }
-async-trait = { workspace = true }
+hex = { workspace = true }
+lazy_static = { workspace = true }
+libsecp256k1 = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
-hex = { workspace = true }
-futures = { workspace = true }
+prometheus = { workspace = true }
 round-based = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "alloc"] }
+serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"], optional = true }
-lazy_static = { workspace = true }
 thiserror = { workspace = true }
 
 # Substrate
-tangle-subxt = { workspace = true, optional = true }
-subxt-signer = { workspace = true, features = ["subxt", "sr25519"], optional = true }
-subxt = { workspace = true, optional = true }
-sp-io = { workspace = true, features = ["disable_allocator", "disable_panic_handler", "disable_oom"] }
+parity-scale-codec = { workspace = true, optional = true }
 sp-core = { workspace = true, features = ["full_crypto"] }
+sp-io = { workspace = true, features = ["disable_allocator", "disable_panic_handler", "disable_oom"] }
 sp-runtime = { workspace = true, features = ["serde"] }
 substrate-prometheus-endpoint = { workspace = true, optional = true }
-parity-scale-codec = { workspace = true, optional = true }
+subxt = { workspace = true, optional = true }
+subxt-signer = { workspace = true, features = ["subxt", "sr25519"], optional = true }
+tangle-subxt = { workspace = true, optional = true }
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -59,9 +59,5 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
 ]
-wasm = [
-    "subxt-signer?/web",
-    "subxt?/web",
-    "subxt?/jsonrpsee",
-]
+wasm = ["subxt-signer?/web", "subxt?/web", "subxt?/jsonrpsee"]
 testing = []

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -28,7 +28,6 @@ getrandom = { workspace = true }
 tracing = { workspace = true, default-features = false }
 tracing-subscriber = { workspace = true, default-features = false }
 tracing-core = { workspace = true, default-features = false }
-color-eyre = { workspace = true }
 
 # Substrate
 tangle-subxt = { workspace = true, optional = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -70,7 +70,6 @@ pub mod prelude {
 
 // Convenience re-exports
 pub use async_trait;
-pub use color_eyre;
 pub use gadget_io;
 #[cfg(feature = "substrate")]
 pub use subxt_signer;
@@ -158,6 +157,10 @@ pub enum Error {
     PrometheusError {
         err: String,
     },
+    #[cfg(feature = "substrate")]
+    Subxt {
+        err: subxt::Error,
+    },
     Other {
         err: String,
     },
@@ -180,6 +183,13 @@ impl core::error::Error for Error {}
 impl From<JobError> for Error {
     fn from(err: JobError) -> Self {
         Error::JobError { err }
+    }
+}
+
+#[cfg(feature = "substrate")]
+impl From<subxt::Error> for Error {
+    fn from(err: subxt::Error) -> Self {
+        Error::Subxt { err }
     }
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,15 +9,15 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-parking_lot = { workspace = true }
+async-trait = { workspace = true }
+auto_impl = { workspace = true }
+futures-timer = { workspace = true }
 gadget-io = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 log = { workspace = true }
-async-trait = { workspace = true }
-auto_impl = { workspace = true }
-sp-core = { workspace = true }
-futures-timer = { workspace = true }
+parking_lot = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+sp-core = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,6 @@ hex = { workspace = true, features = ["alloc"] }
 log = { workspace = true }
 async-trait = { workspace = true }
 auto_impl = { workspace = true }
-futures = { workspace = true }
 sp-core = { workspace = true }
 futures-timer = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/environments/tangle/src/runtime.rs
+++ b/environments/tangle/src/runtime.rs
@@ -62,7 +62,7 @@ impl TangleRuntime {
 
     /// Initialize the TangleRuntime instance by listening for finality notifications.
     /// This method must be called before using the instance.
-    async fn initialize(&self) -> gadget_common::color_eyre::Result<()> {
+    async fn initialize(&self) -> Result<(), gadget_common::Error> {
         let finality_notification_stream = self.client.blocks().subscribe_finalized().await?;
         *self.finality_notification_stream.lock().await = Some(finality_notification_stream);
         Ok(())

--- a/gadget-io/Cargo.toml
+++ b/gadget-io/Cargo.toml
@@ -9,31 +9,31 @@ homepage.workspace = true
 
 [dependencies]
 cfg-if = { workspace = true }
-tracing = { workspace = true, default-features = false, features = ["log", "attributes"] }
 hex = { workspace = true }
-scale-info = { workspace = true, optional = true }
+multiaddr = { workspace = true, default-features = false }
 parity-scale-codec = { workspace = true, optional = true }
+sc-keystore = { workspace = true, optional = true }
+scale-info = { workspace = true, optional = true }
 serde = { workspace = true }
 sp-application-crypto = { workspace = true, default-features = false, features = ["full_crypto"] }
 sp-core = { workspace = true, features = ["serde", "full_crypto"] }
-multiaddr = { workspace = true, default-features = false }
-url = { workspace = true, default-features = false, features = ["alloc", "serde"] }
-thiserror = { workspace = true }
-tsify = { workspace = true, optional = true }
 sp-keystore = { workspace = true, optional = true }
-sc-keystore = { workspace = true, optional = true }
 structopt = { workspace = true, optional = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, optional = true, features = [
     "time",
     "rt",
     "sync",
 ] }
+tracing = { workspace = true, default-features = false, features = ["log", "attributes"] }
+url = { workspace = true, default-features = false, features = ["alloc", "serde"] }
 
 # WASM
+js-sys = { workspace = true, optional = true }
+serde-wasm-bindgen = { workspace = true, optional = true }
+tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
-serde-wasm-bindgen = { workspace = true, optional = true }
-js-sys = { workspace = true, optional = true }
 wasmtimer = { workspace = true, optional = true }
 
 [features]
@@ -56,7 +56,4 @@ wasm-bindgen = [
     "dep:js-sys",
     "dep:wasmtimer",
 ]
-typescript = [
-    "dep:tsify",
-    "wasm-bindgen",
-]
+typescript = ["dep:tsify", "wasm-bindgen"]

--- a/gadget-io/Cargo.toml
+++ b/gadget-io/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 cfg-if = { workspace = true }
 tracing = { workspace = true, default-features = false, features = ["log", "attributes"] }
 hex = { workspace = true }
-scale-info = { workspace = true}
-parity-scale-codec = { workspace = true }
+scale-info = { workspace = true, optional = true }
+parity-scale-codec = { workspace = true, optional = true }
 serde = { workspace = true }
 sp-application-crypto = { workspace = true, default-features = false, features = ["full_crypto"] }
 sp-core = { workspace = true, features = ["serde", "full_crypto"] }
@@ -20,39 +20,41 @@ multiaddr = { workspace = true, default-features = false }
 url = { workspace = true, default-features = false, features = ["alloc", "serde"] }
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }
-wasm-bindgen = { workspace = true, optional = true }
+sp-keystore = { workspace = true, optional = true }
+sc-keystore = { workspace = true, optional = true }
+structopt = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
     "time",
     "rt",
     "sync",
 ] }
 
-[target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen-futures = { workspace = true }
-
-serde-wasm-bindgen = { workspace = true }
-js-sys = { workspace = true }
-tokio = { workspace = true, features = ["sync", "macros", "io-util", "rt", "time"] }
-wasmtimer = { workspace = true }
-
-p256 = { workspace = true, features = ["alloc", "ecdsa"], default-features = false }
-
-
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-sp-keystore = { workspace = true }
-sc-keystore = { workspace = true }
-structopt = { workspace = true }
+# WASM
+wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
+serde-wasm-bindgen = { workspace = true, optional = true }
+js-sys = { workspace = true, optional = true }
+wasmtimer = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
 std = [
     "dep:tokio",
     "sp-application-crypto/std",
+    "dep:sp-keystore",
+    "dep:sc-keystore",
+    "dep:structopt",
+    "dep:scale-info",
+    "dep:parity-scale-codec",
     "tracing/std",
     "url/std",
 ]
 wasm-bindgen = [
     "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:serde-wasm-bindgen",
+    "dep:js-sys",
+    "dep:wasmtimer",
 ]
 typescript = [
     "dep:tsify",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -10,52 +10,45 @@ license.workspace = true
 
 
 [dependencies]
-thiserror = { workspace = true }
-parking_lot = { workspace = true }
-rand_core = { workspace = true, default-features = false }
-rand = { workspace = true, optional = true }
-hex = { workspace = true, default-features = false }
 elliptic-curve = { workspace = true, features = ["alloc", "sec1"] }
+hex = { workspace = true }
+parking_lot = { workspace = true }
+rand_core = { workspace = true }
+rand = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 # Keystore deps
-k256 = { workspace = true, features = ["ecdsa", "ecdsa-core", "arithmetic"] }
 ed25519-zebra = { workspace = true }
+k256 = { workspace = true, features = ["ecdsa", "ecdsa-core", "arithmetic"] }
 schnorrkel = { workspace = true }
 w3f-bls = { workspace = true }
 
 # Metrics deps
-hyper = { workspace = true, default-features = false, features = ["http1", "server"] }
-prometheus = { workspace = true, default-features = false }
+hyper = { workspace = true, features = ["http1", "server"] }
+prometheus = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
 
 # Logging deps
 log = { workspace = true }
 tracing = { workspace = true }
-tracing-log = { workspace = true, default-features = false }
-tracing-subscriber = { workspace = true, default-features = false }
-tracing-wasm = { workspace = true, optional = true }
 
 # Networking deps
-gadget-io = { workspace = true, features = ["std"] }
-gadget-core = { workspace = true, features = ["substrate"] }
-bincode = { workspace = true }
-gadget-common = { workspace = true, features = ["default"] }
-serde = { workspace = true }
 async-trait = { workspace = true }
+bincode = { workspace = true }
 futures = { workspace = true }
+gadget-core = { workspace = true, features = ["substrate"] }
+gadget-common = { workspace = true, features = ["default"] }
+gadget-io = { workspace = true, features = ["std"] }
+serde = { workspace = true }
 
 # Substrate
+sp-core = { workspace = true, features = ["full_crypto"] }
 sp-io = { workspace = true }
-sp-core = { workspace = true, default-features = false, features = ["full_crypto"] }
-
-# WASM-only deps
-getrandom = { workspace = true, optional = true }
-wasm-bindgen-test = { workspace = true, optional = true }
 
 # Event Watchers and Handlers
-tangle-subxt = { workspace = true, default-features = false }
-subxt = { workspace = true, default-features = false }
 backoff = { workspace = true }
+subxt = { workspace = true }
+tangle-subxt = { workspace = true }
 
 # Macros
 gadget-blueprint-proc-macro = { workspace = true }
@@ -82,14 +75,15 @@ features = [
   "autonat"
 ]
 
-[target.'cfg(target_family = "wasm")'.dependencies.libp2p]
-workspace = true
-default-features = false
+# WASM-only deps
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+libp2p = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 hyper = { workspace = true, features = ["client"] }
 
-[dev-dependencies]
+# [dev-dependencies]
 # tangle-test-utils = { workspace = true }
 
 [features]
@@ -102,11 +96,7 @@ std = [
   "sp-io/std",
 ]
 alloc = ["rand_core/alloc", "hex/alloc"]
-wasm = [
-  "getrandom/js",
-  "tracing-wasm",
-  "wasm-bindgen-test",
-]
+wasm = []
 
 # Randomness
 getrandom = ["rand_core/getrandom"]


### PR DESCRIPTION
This removes unused dependencies and sorts the tables.

`common` depended on `color-eyre` just to re-export it. That re-export was only used by `tangle-environment`, so I just made a new `common::Error` variant for it to use instead (https://github.com/webb-tools/gadget/commit/0d8e38e5397f59af81e2d63ed6dadf56754dc685). Outside of that, there are no functionality changes.