### PR TITLE
Make a subset of gadget-sdk no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,7 +4369,6 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "rand",
- "rand_core 0.6.4",
  "schnorrkel",
  "serde",
  "sp-core 34.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
  "hyper 1.4.1",
  "k256",
  "libp2p",
+ "lock_api",
  "log",
  "parking_lot",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ lazy_static = "1.5.0"
 libp2p = { version = "0.54", default-features = false }
 libsecp256k1 = "0.7.1"
 linked-hash-map = { version = "0.5.6", default-features = false }
+lock_api = "0.4.12"
 log = "0.4.22"
 multiaddr = { version = "0.18.1", default-features = false }
 nix = { version = "0.29.0", features = ["process", "signal"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 [dependencies]
 elliptic-curve = { workspace = true, features = ["alloc", "sec1"] }
 hex = { workspace = true }
+lock_api = { workspace = true }
 parking_lot = { workspace = true }
 rand_core = { workspace = true }
 rand = { workspace = true, optional = true }
@@ -56,23 +57,23 @@ gadget-blueprint-proc-macro = { workspace = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies.libp2p]
 workspace = true
 features = [
-  "tokio",
-  "gossipsub",
-  "mdns",
-  "noise",
-  "macros",
-  "yamux",
-  "tcp",
-  "quic",
-  "request-response",
-  "cbor",
-  "identify",
-  "kad",
-  "dcutr",
-  "relay",
-  "ping",
-  "dns",
-  "autonat"
+    "tokio",
+    "gossipsub",
+    "mdns",
+    "noise",
+    "macros",
+    "yamux",
+    "tcp",
+    "quic",
+    "request-response",
+    "cbor",
+    "identify",
+    "kad",
+    "dcutr",
+    "relay",
+    "ping",
+    "dns",
+    "autonat"
 ]
 
 # WASM-only deps
@@ -89,11 +90,11 @@ hyper = { workspace = true, features = ["client"] }
 [features]
 default = ["std"]
 std = [
-  "alloc",
-  "rand",
-  "getrandom",
-  "hex/std",
-  "sp-io/std",
+    "alloc",
+    "rand",
+    "getrandom",
+    "hex/std",
+    "sp-io/std",
 ]
 alloc = ["rand_core/alloc", "hex/alloc"]
 wasm = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,8 +14,7 @@ elliptic-curve = { workspace = true, features = ["alloc", "sec1"] }
 hex = { workspace = true, features = ["alloc"] }
 lock_api = { workspace = true }
 parking_lot = { workspace = true }
-rand_core = { workspace = true, features = ["alloc"] }
-rand = { workspace = true, optional = true }
+rand = { version = "0.8", default-features = false, features = ["alloc"] }
 thiserror = { workspace = true }
 
 # Keystore deps
@@ -90,12 +89,13 @@ hyper = { workspace = true, features = ["client"] }
 [features]
 default = ["std"]
 std = [
-    "rand",
     "getrandom",
     "hex/std",
+    "rand/std",
+    "rand/std_rng",
     "sp-io/std",
 ]
 wasm = []
 
 # Randomness
-getrandom = ["rand_core/getrandom"]
+getrandom = ["rand/getrandom"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,10 +11,10 @@ license.workspace = true
 
 [dependencies]
 elliptic-curve = { workspace = true, features = ["alloc", "sec1"] }
-hex = { workspace = true }
+hex = { workspace = true, features = ["alloc"] }
 lock_api = { workspace = true }
 parking_lot = { workspace = true }
-rand_core = { workspace = true }
+rand_core = { workspace = true, features = ["alloc"] }
 rand = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
@@ -90,13 +90,11 @@ hyper = { workspace = true, features = ["client"] }
 [features]
 default = ["std"]
 std = [
-    "alloc",
     "rand",
     "getrandom",
     "hex/std",
     "sp-io/std",
 ]
-alloc = ["rand_core/alloc", "hex/alloc"]
 wasm = []
 
 # Randomness

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 
 [dependencies]
 elliptic-curve = { workspace = true, features = ["alloc", "sec1"] }
+getrandom = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 lock_api = { workspace = true }
 parking_lot = { workspace = true }
@@ -75,11 +76,6 @@ features = [
     "autonat"
 ]
 
-# WASM-only deps
-[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-getrandom = { workspace = true, features = ["js"] }
-libp2p = { workspace = true }
-
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 hyper = { workspace = true, features = ["client"] }
 
@@ -95,7 +91,9 @@ std = [
     "rand/std_rng",
     "sp-io/std",
 ]
-wasm = []
+wasm = [
+    "getrandom/js",
+]
 
 # Randomness
 getrandom = ["rand/getrandom"]

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -1,4 +1,5 @@
 use crate::events_watcher::tangle::TangleConfig;
+use alloc::string::{String, ToString};
 
 /// Gadget environment.
 #[derive(Debug, Clone)]

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -1,10 +1,11 @@
 use crate::events_watcher::tangle::TangleConfig;
+use crate::keystore::backend::GenericKeyStore;
 use alloc::string::{String, ToString};
 
 /// Gadget environment.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct GadgetEnvironment {
+pub struct GadgetEnvironment<RwLock: lock_api::RawRwLock> {
     /// Tangle RPC endpoint.
     pub tangle_rpc_endpoint: String,
     /// Keystore URI
@@ -31,6 +32,8 @@ pub struct GadgetEnvironment {
     ///
     /// If this is set to true, the gadget should do some work and register the operator on the blueprint.
     pub is_registration: bool,
+
+    _lock: core::marker::PhantomData<RwLock>,
 }
 
 /// An error type for the gadget environment.
@@ -74,11 +77,28 @@ pub enum Error {
 }
 
 /// Loads the [`GadgetEnvironment`] from the current environment.
+///
 /// # Errors
 ///
 /// This function will return an error if any of the required environment variables are missing.
 #[cfg(feature = "std")]
-pub fn load() -> Result<GadgetEnvironment, Error> {
+pub fn load() -> Result<GadgetEnvironment<parking_lot::RawRwLock>, Error> {
+    load_with_lock::<parking_lot::RawRwLock>()
+}
+
+/// Loads the [`GadgetEnvironment`] from the current environment.
+///
+/// This allows callers to specify the `RwLock` implementation to use.
+///
+/// # Errors
+///
+/// This function will return an error if any of the required environment variables are missing.
+pub fn load_with_lock<RwLock: lock_api::RawRwLock>() -> Result<GadgetEnvironment<RwLock>, Error> {
+    load_inner::<RwLock>()
+}
+
+#[cfg(feature = "std")]
+fn load_inner<RwLock: lock_api::RawRwLock>() -> Result<GadgetEnvironment<RwLock>, Error> {
     let is_registration = std::env::var("REGISTRATION_MODE_ON").is_ok();
     Ok(GadgetEnvironment {
         tangle_rpc_endpoint: std::env::var("RPC_URL")
@@ -101,21 +121,22 @@ pub fn load() -> Result<GadgetEnvironment, Error> {
             )
         },
         is_registration,
+        _lock: core::marker::PhantomData,
     })
 }
 
 #[cfg(not(feature = "std"))]
-pub fn load() -> Result<GadgetEnvironment, Error> {
+pub fn load_inner<RwLock: lock_api::RawRwLock>() -> Result<GadgetEnvironment<RwLock>, Error> {
     unimplemented!("Implement loading env for no_std")
 }
 
-impl GadgetEnvironment {
+impl<RwLock: lock_api::RawRwLock> GadgetEnvironment<RwLock> {
     /// Loads the `KeyStore` from the current environment.
     ///
     /// # Errors
     ///
     /// This function will return an error if the keystore URI is unsupported.
-    pub fn keystore(&self) -> Result<crate::keystore::backend::GenericKeyStore, Error> {
+    pub fn keystore(&self) -> Result<GenericKeyStore<RwLock>, Error> {
         #[cfg(feature = "std")]
         use crate::keystore::backend::fs::FilesystemKeystore;
         use crate::keystore::backend::{mem::InMemoryKeystore, GenericKeyStore};

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -115,6 +115,7 @@ impl GadgetEnvironment {
     ///
     /// This function will return an error if the keystore URI is unsupported.
     pub fn keystore(&self) -> Result<crate::keystore::backend::GenericKeyStore, Error> {
+        #[cfg(feature = "std")]
         use crate::keystore::backend::fs::FilesystemKeystore;
         use crate::keystore::backend::{mem::InMemoryKeystore, GenericKeyStore};
 
@@ -122,6 +123,7 @@ impl GadgetEnvironment {
             uri if uri == "file::memory:" || uri == ":memory:" => {
                 Ok(GenericKeyStore::Mem(InMemoryKeystore::new()))
             }
+            #[cfg(feature = "std")]
             uri if uri.starts_with("file:") || uri.starts_with("file://") => {
                 let path = uri
                     .trim_start_matches("file://")

--- a/sdk/src/events_watcher/mod.rs
+++ b/sdk/src/events_watcher/mod.rs
@@ -5,6 +5,8 @@
 //! of an event watcher polls for blocks. Implementations of the event watcher trait define an
 //! action to take when the specified event is found in a block at the `handle_event` api.
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::time::Duration;
 
 use futures::TryFutureExt;
@@ -28,7 +30,7 @@ pub enum Error {
     ForceRestart,
     /// An error occurred in the event handler.
     #[error(transparent)]
-    Handler(#[from] Box<dyn std::error::Error + Send + Sync>),
+    Handler(#[from] Box<dyn core::error::Error + Send + Sync>),
 }
 
 /// A type alias to extract the event handler type from the event watcher.

--- a/sdk/src/keystore/backend/mem.rs
+++ b/sdk/src/keystore/backend/mem.rs
@@ -1,9 +1,8 @@
 //! In-Memory Keystore Backend that supports different cryptographic key operations such as key generation, signing, and public key retrieval.
 
-#[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, sync::Arc};
-
-use std::{collections::BTreeMap, sync::Arc};
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 use w3f_bls::SerializableToBytes;
 
 use parking_lot::RwLock;

--- a/sdk/src/keystore/backend/mod.rs
+++ b/sdk/src/keystore/backend/mod.rs
@@ -12,15 +12,15 @@ pub mod fs;
 /// A Generic Key Store that can be backed by different keystore backends.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub enum GenericKeyStore {
+pub enum GenericKeyStore<RwLock: lock_api::RawRwLock> {
     /// In-Memory Keystore
-    Mem(mem::InMemoryKeystore),
+    Mem(mem::InMemoryKeystore<RwLock>),
     /// Filesystem Keystore
     #[cfg(feature = "std")]
     Fs(fs::FilesystemKeystore),
 }
 
-impl super::Backend for GenericKeyStore {
+impl<RwLock: lock_api::RawRwLock> super::Backend for GenericKeyStore<RwLock> {
     fn sr25519_generate_new(
         &self,
         seed: Option<&[u8]>,

--- a/sdk/src/keystore/backend/mod.rs
+++ b/sdk/src/keystore/backend/mod.rs
@@ -1,5 +1,7 @@
 //! Keystore backend implementations.
 
+use alloc::vec::Vec;
+
 /// In-Memory Keystore Backend
 pub mod mem;
 

--- a/sdk/src/keystore/backend/mod.rs
+++ b/sdk/src/keystore/backend/mod.rs
@@ -4,6 +4,7 @@
 pub mod mem;
 
 /// Filesystem Keystore Backend
+#[cfg(feature = "std")]
 pub mod fs;
 
 /// A Generic Key Store that can be backed by different keystore backends.
@@ -13,6 +14,7 @@ pub enum GenericKeyStore {
     /// In-Memory Keystore
     Mem(mem::InMemoryKeystore),
     /// Filesystem Keystore
+    #[cfg(feature = "std")]
     Fs(fs::FilesystemKeystore),
 }
 
@@ -23,6 +25,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<super::sr25519::Public, super::Error> {
         match self {
             Self::Mem(backend) => backend.sr25519_generate_new(seed),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.sr25519_generate_new(seed),
         }
     }
@@ -34,6 +37,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::sr25519::Signature>, super::Error> {
         match self {
             Self::Mem(backend) => backend.sr25519_sign(public, msg),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.sr25519_sign(public, msg),
         }
     }
@@ -44,6 +48,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<super::ed25519::Public, super::Error> {
         match self {
             Self::Mem(backend) => backend.ed25519_generate_new(seed),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.ed25519_generate_new(seed),
         }
     }
@@ -55,6 +60,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::ed25519::Signature>, super::Error> {
         match self {
             Self::Mem(backend) => backend.ed25519_sign(public, msg),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.ed25519_sign(public, msg),
         }
     }
@@ -65,6 +71,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<super::ecdsa::Public, super::Error> {
         match self {
             Self::Mem(backend) => backend.ecdsa_generate_new(seed),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.ecdsa_generate_new(seed),
         }
     }
@@ -76,6 +83,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::ecdsa::Signature>, super::Error> {
         match self {
             Self::Mem(backend) => backend.ecdsa_sign(public, msg),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.ecdsa_sign(public, msg),
         }
     }
@@ -86,6 +94,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<super::bls381::Public, super::Error> {
         match self {
             Self::Mem(backend) => backend.bls381_generate_new(seed),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.bls381_generate_new(seed),
         }
     }
@@ -97,6 +106,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::bls381::Signature>, super::Error> {
         match self {
             Self::Mem(backend) => backend.bls381_sign(public, msg),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.bls381_sign(public, msg),
         }
     }
@@ -107,6 +117,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::sr25519::Secret>, super::Error> {
         match self {
             Self::Mem(backend) => backend.expose_sr25519_secret(public),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.expose_sr25519_secret(public),
         }
     }
@@ -117,6 +128,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::ecdsa::Secret>, super::Error> {
         match self {
             Self::Mem(backend) => backend.expose_ecdsa_secret(public),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.expose_ecdsa_secret(public),
         }
     }
@@ -127,6 +139,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::ed25519::Secret>, super::Error> {
         match self {
             Self::Mem(backend) => backend.expose_ed25519_secret(public),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.expose_ed25519_secret(public),
         }
     }
@@ -137,6 +150,7 @@ impl super::Backend for GenericKeyStore {
     ) -> Result<Option<super::bls381::Secret>, super::Error> {
         match self {
             Self::Mem(backend) => backend.expose_bls381_secret(public),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.expose_bls381_secret(public),
         }
     }
@@ -144,6 +158,7 @@ impl super::Backend for GenericKeyStore {
     fn iter_sr25519(&self) -> impl Iterator<Item = super::sr25519::Public> {
         match self {
             Self::Mem(backend) => backend.iter_sr25519().collect::<Vec<_>>().into_iter(),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.iter_sr25519().collect::<Vec<_>>().into_iter(),
         }
     }
@@ -151,6 +166,7 @@ impl super::Backend for GenericKeyStore {
     fn iter_ecdsa(&self) -> impl Iterator<Item = super::ecdsa::Public> {
         match self {
             Self::Mem(backend) => backend.iter_ecdsa().collect::<Vec<_>>().into_iter(),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.iter_ecdsa().collect::<Vec<_>>().into_iter(),
         }
     }
@@ -158,6 +174,7 @@ impl super::Backend for GenericKeyStore {
     fn iter_ed25519(&self) -> impl Iterator<Item = super::ed25519::Public> {
         match self {
             Self::Mem(backend) => backend.iter_ed25519().collect::<Vec<_>>().into_iter(),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.iter_ed25519().collect::<Vec<_>>().into_iter(),
         }
     }
@@ -165,6 +182,7 @@ impl super::Backend for GenericKeyStore {
     fn iter_bls381(&self) -> impl Iterator<Item = super::bls381::Public> {
         match self {
             Self::Mem(backend) => backend.iter_bls381().collect::<Vec<_>>().into_iter(),
+            #[cfg(feature = "std")]
             Self::Fs(backend) => backend.iter_bls381().collect::<Vec<_>>().into_iter(),
         }
     }

--- a/sdk/src/keystore/bls381.rs
+++ b/sdk/src/keystore/bls381.rs
@@ -11,6 +11,7 @@ pub type Secret = w3f_bls::SecretKey<TinyBLS381>;
 /// BLS12-381 signature.
 pub type Signature = w3f_bls::Signature<TinyBLS381>;
 
+#[must_use]
 pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> Secret {
     match seed {
         Some(seed) => Secret::from_seed(seed),
@@ -23,10 +24,12 @@ pub fn sign(secret: &mut Secret, msg: &[u8]) -> Signature {
     secret.sign(&message, &mut random::getrandom_or_panic())
 }
 
+#[must_use]
 pub fn to_public(secret: &Secret) -> Public {
     secret.clone().into_public()
 }
 
+#[must_use]
 pub fn secret_from_bytes(bytes: &[u8]) -> Secret {
     Secret::from_seed(bytes)
 }

--- a/sdk/src/keystore/ecdsa.rs
+++ b/sdk/src/keystore/ecdsa.rs
@@ -8,6 +8,11 @@ pub use k256::SecretKey as Secret;
 
 use crate::random;
 
+/// Generate a new secret key.
+///
+/// # Errors
+///
+/// Returns an error if the secret key cannot be created from `seed`.
 pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> elliptic_curve::Result<Secret> {
     if let Some(seed) = seed {
         Secret::from_bytes(seed.into())
@@ -17,11 +22,17 @@ pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> elliptic_curve::Resul
     }
 }
 
+#[must_use]
 pub fn sign(secret: &Secret, msg: &[u8]) -> Signature {
     let mut keypair = k256::ecdsa::SigningKey::from(secret);
     keypair.sign(msg)
 }
 
+/// Create a secret key from a byte slice.
+///
+/// # Errors
+///
+/// Returns an error if the secret key cannot be created from `bytes`.
 pub fn secret_from_bytes(bytes: &[u8]) -> elliptic_curve::Result<Secret> {
     Secret::from_bytes(bytes.into())
 }

--- a/sdk/src/keystore/ed25519.rs
+++ b/sdk/src/keystore/ed25519.rs
@@ -6,6 +6,11 @@ pub use ed25519_zebra::VerificationKey as Public;
 
 use crate::random;
 
+/// Generate a new keypair.
+///
+/// # Errors
+///
+/// Returns an error if the `seed` is not the correct length (32).
 pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> Result<Secret, ed25519_zebra::Error> {
     match seed {
         Some(seed) => Secret::try_from(seed).map_err(|_| ed25519_zebra::Error::InvalidSliceLength),
@@ -13,14 +18,21 @@ pub fn generate_with_optional_seed(seed: Option<&[u8]>) -> Result<Secret, ed2551
     }
 }
 
+#[must_use]
 pub fn sign(secret: &Secret, msg: &[u8]) -> Signature {
     secret.sign(msg)
 }
 
+#[must_use]
 pub fn to_public(secret: &Secret) -> Public {
     Public::from(secret)
 }
 
+/// Create a signing key from a byte slice.
+///
+/// # Errors
+///
+/// Returns an error if the slice is not the correct length (32).
 pub fn secret_from_bytes(bytes: &[u8]) -> Result<Secret, ed25519_zebra::Error> {
     Secret::try_from(bytes).map_err(|_| ed25519_zebra::Error::InvalidSliceLength)
 }

--- a/sdk/src/keystore/error.rs
+++ b/sdk/src/keystore/error.rs
@@ -6,6 +6,7 @@
 pub enum Error {
     /// An I/O error occurred
     #[error(transparent)]
+    #[cfg(feature = "std")]
     Io(#[from] std::io::Error),
     /// An error occurred during sr25519 module operation
     #[error("sr25519: {0}")]

--- a/sdk/src/keystore/mod.rs
+++ b/sdk/src/keystore/mod.rs
@@ -24,20 +24,21 @@
 
 /// Backend modules
 pub mod backend;
+
 /// BLS381 Support
-mod bls381;
+pub mod bls381;
 
 /// ECDSA Support
-mod ecdsa;
+pub mod ecdsa;
 
 /// Ed25519 Support
-mod ed25519;
+pub mod ed25519;
 
 /// Keystore errors module
-mod error;
+pub mod error;
 
 /// Schnorrkel Support
-mod sr25519;
+pub mod sr25519;
 
 pub use error::Error;
 

--- a/sdk/src/keystore/mod.rs
+++ b/sdk/src/keystore/mod.rs
@@ -6,7 +6,7 @@
 //! Currently, we support different backends:
 //!
 //! - `memory`: A simple in-memory storage (enabled by default)
-//! - `file`: A storage that saves the keys to a file (`keystore-fs` feature)
+//! - `file`: A storage that saves the keys to a file (`std` feature, enabled by default)
 //! - `kms`: A storage that uses a AWS Key Management System (`keystore-kms` feature)*
 //! - `substrate`: Uses Substrate's Framework keystore (`keystore-substrate` feature)*
 //! and a lot more to be added in the future.

--- a/sdk/src/keystore/sr25519.rs
+++ b/sdk/src/keystore/sr25519.rs
@@ -1,6 +1,6 @@
 //! Schnorrkel keypair implementation.
 
-use rand_core::RngCore;
+use rand::RngCore;
 pub use schnorrkel::PublicKey as Public;
 pub use schnorrkel::SecretKey as Secret;
 pub use schnorrkel::Signature;

--- a/sdk/src/keystore/sr25519.rs
+++ b/sdk/src/keystore/sr25519.rs
@@ -8,6 +8,12 @@ pub use schnorrkel::Signature;
 /// The context used for signing.
 const SIGNING_CTX: &[u8] = b"substrate";
 
+/// Generate a new secret key.
+///
+/// # Errors
+///
+/// * `seed` is not the correct length (64).
+/// * `seed` contains an invalid scalar.
 pub fn generate_with_optional_seed(
     seed: Option<&[u8]>,
 ) -> Result<Secret, schnorrkel::SignatureError> {
@@ -19,11 +25,24 @@ pub fn generate_with_optional_seed(
     }
 }
 
+/// Sign a message with the given secret key.
+///
+/// # Errors
+///
+/// Returns an error if the signature fails to be verified.
 pub fn sign(secret: &Secret, msg: &[u8]) -> Result<Signature, schnorrkel::SignatureError> {
     let public = secret.to_public();
     secret.sign_simple_doublecheck(SIGNING_CTX, msg, &public)
 }
 
+/// Create a secret key from a byte slice.
+///
+/// If the slice is 32 bytes long, a new random nonce is added to the secret key.
+///
+/// # Errors
+///
+/// * `bytes` is not the correct length (32 or 64).
+/// * `bytes` contains an invalid scalar.
 pub fn secret_from_bytes(bytes: &[u8]) -> Result<Secret, schnorrkel::SignatureError> {
     if bytes.len() == 32 {
         // add a new random nonce to the secret key

--- a/sdk/src/keystore/sr25519.rs
+++ b/sdk/src/keystore/sr25519.rs
@@ -1,5 +1,6 @@
 //! Schnorrkel keypair implementation.
 
+use rand_core::RngCore;
 pub use schnorrkel::PublicKey as Public;
 pub use schnorrkel::SecretKey as Secret;
 pub use schnorrkel::Signature;
@@ -29,7 +30,7 @@ pub fn secret_from_bytes(bytes: &[u8]) -> Result<Secret, schnorrkel::SignatureEr
         let mut final_bytes = [0u8; 64];
         final_bytes[..32].copy_from_slice(bytes);
         let mut rng = crate::random::getrandom_or_panic();
-        rand::Rng::fill(&mut rng, &mut final_bytes[32..]);
+        rng.fill_bytes(&mut final_bytes[32..]);
         Secret::from_bytes(&final_bytes[..])
     } else {
         Secret::from_bytes(bytes)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -20,7 +20,6 @@
 extern crate alloc;
 
 /// Keystore Module
-#[cfg(not(feature = "wasm"))]
 pub mod keystore;
 
 /// Metrics Module

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -17,7 +17,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 /// Keystore Module
@@ -42,6 +41,7 @@ pub mod tx;
 
 pub use tangle_subxt;
 
+#[cfg(feature = "std")]
 pub mod network;
 
 pub mod slashing;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -27,7 +27,6 @@ pub mod keystore;
 // pub mod metrics;
 
 /// Randomness generation module
-#[cfg(not(feature = "wasm"))]
 pub mod random;
 
 /// Blockchain Events Watcher Module

--- a/sdk/src/random.rs
+++ b/sdk/src/random.rs
@@ -1,7 +1,7 @@
 //! Returns `OsRng` with `getrandom`, or a `CryptoRng` which panics without `getrandom`.
 
 /// Re-export [`rand_core`] types to simplify dependences
-pub use rand_core::{self, CryptoRng, CryptoRngCore, RngCore, SeedableRng};
+pub use rand::{self, CryptoRng, RngCore, SeedableRng};
 
 /// Returns `OsRng` with `getrandom`, or a `CryptoRng` which panics without `getrandom`.
 #[cfg(all(feature = "getrandom", not(feature = "std")))]

--- a/sdk/src/slashing/reports.rs
+++ b/sdk/src/slashing/reports.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::unused_async)]
 
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use async_trait::async_trait;
-use std::time::Duration;
+use core::time::Duration;
 
 #[async_trait]
 pub trait QoSReporter {


### PR DESCRIPTION
Each commit message speaks for itself, the only major change is the addition of `GadgetEnvironment::load_with_lock<R>()` where `R` is `lock_api::RawRwLock`. This allows callers to bring their own lock in `no_std` environments. `GadgetEnvironment::load()` is now `std` only, and will use `parking_lot::RawRwLock` as before.