### PR TITLE
sdk: Switch to `backon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,16 +1441,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "e4fa97bb310c33c811334143cf64c5bb2b7b3c06e453db6b095d7061eff8f113"
 dependencies = [
- "futures-core",
- "getrandom",
- "instant",
- "pin-project-lite",
- "rand",
+ "fastrand",
+ "gloo-timers 0.3.0",
  "tokio",
 ]
 
@@ -4198,7 +4195,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
 ]
 
@@ -4320,7 +4317,7 @@ dependencies = [
  "alloy-transport",
  "async-trait",
  "auto_impl",
- "backoff",
+ "backon",
  "bincode",
  "derive_more 1.0.0",
  "ed25519-zebra 4.0.3",
@@ -4702,6 +4699,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ sp-session = { version = "35.0.0" }
 
 async-trait = "0.1.82"
 auto_impl = "1.2.0"
-backoff = { version = "0.4.0", default-features = false }
+backon = { version = "1.2.0", default-features = false }
 bincode = "1.3.3"
 cargo-generate = "0.21.3"
 cfg-if = "1.0.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -31,7 +31,7 @@ w3f-bls = { workspace = true }
 hyper = { workspace = true, features = ["http1", "server"], optional = true }
 hyper-util = { workspace = true, features = ["server"], optional = true }
 prometheus = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"], optional = true }
+tokio = { workspace = true, optional = true }
 
 # Logging deps
 log = { workspace = true }
@@ -51,7 +51,7 @@ sp-core = { workspace = true, features = ["full_crypto"] }
 sp-io = { workspace = true }
 
 # Event Watchers and Handlers
-backoff = { workspace = true, optional = true }
+backon = { workspace = true, optional = true }
 subxt = { workspace = true, optional = true }
 subxt-signer = { workspace = true, features = ["sr25519"] }
 tangle-subxt = { workspace = true }
@@ -60,7 +60,7 @@ tangle-subxt = { workspace = true }
 alloy-contract = { workspace = true }
 alloy-network = { workspace = true }
 alloy-primitives = { workspace = true }
-alloy-provider = { workspace = true }
+alloy-provider = { workspace = true, optional = true }
 alloy-pubsub = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-signer = { workspace = true }
@@ -106,13 +106,14 @@ hyper = { workspace = true, features = ["client"] }
 default = ["std"]
 
 std = [
-    "dep:backoff",
+    "dep:alloy-provider",
+    "dep:backon",
     "dep:parking_lot",
     "dep:hyper",
     "dep:hyper-util",
     "dep:subxt",
     "dep:tokio",
-    "backoff/tokio",
+    "backon/tokio-sleep",
     "getrandom",
     "gadget-io/std",
     "hex/std",
@@ -122,11 +123,15 @@ std = [
     "sqlx",
     "subxt/native",
     "tangle-subxt/std",
+    "tokio/rt-multi-thread",
+    "tokio/parking_lot",
 ]
 wasm = [
-    "dep:backoff",
+    "dep:backon",
     "dep:subxt",
-    "backoff/wasm-bindgen",
+    "dep:tokio",
+    "backon/gloo-timers-sleep",
+    "gadget-io/wasm-bindgen",
     "getrandom/js",
     "subxt/web",
     "tangle-subxt/web",

--- a/sdk/src/clients/mod.rs
+++ b/sdk/src/clients/mod.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 
+#[cfg(feature = "std")]
 pub mod tangle;
 
 #[async_trait]

--- a/sdk/src/events_watcher/error.rs
+++ b/sdk/src/events_watcher/error.rs
@@ -8,10 +8,6 @@ pub enum Error {
     // TODO: Add feature flag for substrate/tangle
     #[error(transparent)]
     Subxt(#[from] subxt::Error),
-    /// An error occurred in the backoff mechanism.
-    #[error(transparent)]
-    #[cfg(any(feature = "std", feature = "wasm"))]
-    Backoff(#[from] backoff::Error<subxt::Error>),
     /// An error occurred in Alloy transport.
     // TODO: Add feature flag for EVM/eigenlayer/etc.
     #[error(transparent)]

--- a/sdk/src/events_watcher/evm.rs
+++ b/sdk/src/events_watcher/evm.rs
@@ -1,6 +1,7 @@
 //! EVM Event Watcher Module
 
-use crate::events_watcher::{error::Error, ConstantWithMaxRetryCount};
+use crate::events_watcher::error::Error;
+use crate::events_watcher::retry::UnboundedConstantBuilder;
 use crate::store::LocalDatabase;
 use alloy_network::Network;
 use alloy_network::ReceiptResponse;
@@ -10,6 +11,7 @@ use alloy_rpc_types::BlockNumberOrTag;
 use alloy_rpc_types::{Filter, Log};
 use alloy_sol_types::SolEvent;
 use alloy_transport::Transport;
+use backon::{ConstantBuilder, Retryable};
 use futures::TryFutureExt;
 use std::{ops::Deref, time::Duration};
 
@@ -78,14 +80,11 @@ pub trait EventHandlerWithRetry<T: Config>: EventHandler<T> + Send + Sync + 'sta
         &self,
         contract: &Self::Contract,
         (event, log): (Self::Event, Log),
-        backoff: impl backoff::backoff::Backoff + Send + Sync + 'static,
+        backoff: impl backon::Backoff + Send + Sync + 'static,
     ) -> Result<(), Error> {
         let ev = event.clone();
-        let wrapped_task = || {
-            self.handle_event(contract, (ev.clone(), log.clone()))
-                .map_err(backoff::Error::transient)
-        };
-        backoff::future::retry(backoff, wrapped_task).await?;
+        let wrapped_task = || self.handle_event(contract, (ev.clone(), log.clone()));
+        wrapped_task.retry(backoff).await?;
         Ok(())
     }
 }
@@ -128,7 +127,7 @@ pub trait EventWatcher<T: Config>: Send + Sync {
         handlers: Vec<EventHandlerFor<Self, T>>,
     ) -> Result<(), Error> {
         let local_db = LocalDatabase::open("./db");
-        let backoff = backoff::backoff::Constant::new(Duration::from_secs(1));
+        let backoff = UnboundedConstantBuilder::new(Duration::from_secs(1));
         let task = || async {
             let step = 100;
             let chain_id: u64 = contract
@@ -136,7 +135,6 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                 .root()
                 .get_chain_id()
                 .map_err(Into::into)
-                .map_err(backoff::Error::transient)
                 .await?;
 
             // we only query this once, at the start of the events watcher.
@@ -145,7 +143,6 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                 .provider()
                 .get_block_number()
                 .map_err(Into::into)
-                .map_err(backoff::Error::transient)
                 .await?;
 
             local_db.set(
@@ -157,8 +154,7 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                 .provider()
                 .get_transaction_receipt(Self::GENESIS_TX_HASH)
                 .await
-                .map_err(Into::into)
-                .map_err(backoff::Error::transient)?
+                .map_err(Into::into)?
                 .map(|receipt| receipt.block_number().unwrap_or_default())
                 .unwrap_or_default();
 
@@ -174,11 +170,7 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                         .to_block(BlockNumberOrTag::Number(dest_block)),
                 );
 
-                let events = events_filter
-                    .query()
-                    .await
-                    .map_err(Into::into)
-                    .map_err(backoff::Error::transient)?;
+                let events = events_filter.query().await.map_err(Into::into)?;
                 let number_of_events = events.len();
                 tracing::trace!("Found #{number_of_events} events");
                 for (event, log) in events {
@@ -188,10 +180,9 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                     const MAX_RETRY_COUNT: usize = 5;
                     let tasks = handlers.iter().map(|handler| {
                         // a constant backoff with maximum retry count is used here.
-                        let backoff = ConstantWithMaxRetryCount::new(
-                            Duration::from_millis(100),
-                            MAX_RETRY_COUNT,
-                        );
+                        let backoff = ConstantBuilder::default()
+                            .with_delay(Duration::from_millis(100))
+                            .with_max_times(MAX_RETRY_COUNT);
                         handler.handle_event_with_retry(
                             &contract,
                             (event.clone(), log.clone()),
@@ -239,7 +230,6 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                         .provider()
                         .get_block_number()
                         .map_err(Into::into)
-                        .map_err(backoff::Error::transient)
                         .await?;
                     local_db.set(
                         &format!("TARGET_BLOCK_NUMBER_{}", contract.address()),
@@ -248,7 +238,7 @@ pub trait EventWatcher<T: Config>: Send + Sync {
                 }
             }
         };
-        backoff::future::retry(backoff, task).await?;
+        task.retry(backoff).await?;
         Ok(())
     }
 }

--- a/sdk/src/events_watcher/mod.rs
+++ b/sdk/src/events_watcher/mod.rs
@@ -9,45 +9,8 @@
 pub mod error;
 pub use error::Error;
 
+#[cfg(feature = "std")]
 pub mod evm;
+mod retry;
 pub mod substrate;
 pub mod tangle;
-
-use core::time::Duration;
-
-/// Constant with Max Retry Count is a backoff policy which always returns
-/// a constant duration, until it exceeds the maximum retry count.
-#[derive(Debug, Clone, Copy)]
-pub struct ConstantWithMaxRetryCount {
-    interval: Duration,
-    max_retry_count: usize,
-    count: usize,
-}
-
-impl ConstantWithMaxRetryCount {
-    /// Creates a new Constant backoff with `interval` and `max_retry_count`.
-    /// `interval` is the duration to wait between retries, and `max_retry_count` is the maximum
-    /// number of retries, after which we return `None` to indicate that we should stop retrying.
-    #[must_use]
-    pub fn new(interval: Duration, max_retry_count: usize) -> Self {
-        Self {
-            interval,
-            max_retry_count,
-            count: 0,
-        }
-    }
-}
-
-#[cfg(any(feature = "std", feature = "wasm"))]
-impl backoff::backoff::Backoff for ConstantWithMaxRetryCount {
-    fn reset(&mut self) {
-        self.count = 0;
-    }
-
-    fn next_backoff(&mut self) -> Option<Duration> {
-        (self.count < self.max_retry_count).then(|| {
-            self.count += 1;
-            self.interval
-        })
-    }
-}

--- a/sdk/src/events_watcher/retry.rs
+++ b/sdk/src/events_watcher/retry.rs
@@ -1,0 +1,34 @@
+use core::time::Duration;
+
+/// A backoff policy which always returns a constant duration, with no maximum retry count.
+#[derive(Debug, Clone, Copy)]
+pub struct UnboundedConstantBuilder {
+    interval: Duration,
+}
+
+impl UnboundedConstantBuilder {
+    /// Creates a new unbounded Constant backoff
+    ///
+    /// * `interval` is the duration to wait between retries.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+}
+
+impl backon::BackoffBuilder for UnboundedConstantBuilder {
+    type Backoff = UnboundedConstantBuilder;
+
+    fn build(self) -> Self::Backoff {
+        self
+    }
+}
+
+impl Iterator for UnboundedConstantBuilder {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.interval)
+    }
+}

--- a/sdk/src/events_watcher/substrate.rs
+++ b/sdk/src/events_watcher/substrate.rs
@@ -67,7 +67,7 @@ where
         &self,
         client: OnlineClient<RuntimeConfig>,
         (events, block_number): (subxt::events::Events<RuntimeConfig>, u64),
-        backoff: impl backon::BackoffBuilder + Send + Sync + 'static,
+        backoff: impl backon::BackoffBuilder + 'static,
     ) -> Result<(), Error> {
         if !self.can_handle_events(events.clone()).await? {
             return Ok(());

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,7 +7,7 @@
 )]
 //! Gadget SDK
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(feature = "wasm")), no_std)]
 
 extern crate alloc;
 

--- a/sdk/src/mutex_ext.rs
+++ b/sdk/src/mutex_ext.rs
@@ -1,6 +1,6 @@
+use gadget_io::time::error::Elapsed;
 use std::time::Duration;
 use tokio::sync::MutexGuard;
-use tokio::time::error::Elapsed;
 
 /// An extension trait for tokio Mutex.
 ///


### PR DESCRIPTION
`backoff` hasn't been updated in years, and `backon` supports `wasm32-unknown-unknown`. Most of the `events_watcher` module builds on WASM now.

Part of #189