### PR TITLE
Pause work on WASM support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,8 @@ jobs:
       - name: Test each feature
         run: cargo hack test --each-feature --exclude-features wasm --package=${{ matrix.package }}
 
-  # TODO
-  #      - name: Test wasm build
-  #        run: cargo hack build --target wasm32-unknown-unknown --package=${{ matrix.package }} --no-default-features --features wasm --ignore-unknown-features
+      - name: Test wasm build
+        run: cargo hack build --target wasm32-unknown-unknown --package=${{ matrix.package }} --no-default-features --features wasm --ignore-unknown-features
 
   linting:
     timeout-minutes: 120

--- a/sdk/src/benchmark/mod.rs
+++ b/sdk/src/benchmark/mod.rs
@@ -26,6 +26,7 @@ impl Runtime for TokioRuntime {
 
 /// A benchmarking harness.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Bencher<R> {
     /// The runtime to use for running benchmarks.
     runtime: R,
@@ -109,6 +110,7 @@ impl<R: Runtime> Bencher<R> {
     /// let summary = bencher.stop("my_benchmark", 0);
     /// println!("{}", summary);
     /// ```
+    #[cfg(feature = "std")] // TODO: Benchmark execution time for WASM?
     pub fn stop<N: ToString>(&self, name: N, job_id: u8) -> BenchmarkSummary {
         let pid = sysinfo::get_current_pid().expect("Failed to get current process ID");
         let s = sysinfo::System::new_all();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 /// Benchmark Module
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "wasm"))]
 pub mod benchmark;
 /// Blockchain clients
 #[cfg(any(feature = "std", feature = "wasm"))]
@@ -33,7 +33,7 @@ pub mod metrics;
 #[cfg(any(feature = "std", feature = "wasm"))]
 pub mod mutex_ext;
 /// Network Module
-#[cfg(feature = "std")]
+#[cfg(feature = "std")] // TODO: Eventually open this up to WASM
 pub mod network;
 /// Prometheus metrics configuration
 #[cfg(any(feature = "std", feature = "wasm"))]
@@ -41,7 +41,7 @@ pub mod prometheus;
 /// Randomness generation module
 pub mod random;
 /// Gadget Runner Module
-#[cfg(feature = "std")]
+#[cfg(feature = "std")] // TODO: Eventually open this up to WASM
 pub mod run;
 /// Slashing and quality of service utilities
 pub mod slashing;


### PR DESCRIPTION
A lot of the SDK is WASM compatible, this enables the CI checks to make sure that it continues to stay that way. Additional features for WASM are on hold for now.

closes #189