### PR TITLE
ci: do not create release from cargo-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@
 # * uploads those artifacts to temporary workflow zip
 # * on success, uploads the artifacts to a GitHub Release
 #
-# Note that the GitHub Release will be created with a generated
-# title/body based on your changelogs.
+# Note that a GitHub Release with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
 
 name: Release
 permissions:
@@ -261,14 +261,12 @@ jobs:
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          # If we're editing a release in place, we need to upload things ahead of time
+          gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
 
   announce:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,8 @@ eigensdk-rs = { git = "https://github.com/webb-tools/eigensdk-rs.git", branch = 
 cargo-dist-version = "0.22.1"
 # CI backends to support
 ci = "github"
+# Do not create release, as Release-plz will do this for us.
+create-release = false
 github-build-setup = "build-setup.yml"
 # The installers to generate for each app
 installers = ["shell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ eigensdk-rs = { git = "https://github.com/webb-tools/eigensdk-rs.git", branch = 
 cargo-dist-version = "0.22.1"
 # CI backends to support
 ci = "github"
-# Do not create release, as Release-plz will do this for us.
+# Whether cargo-dist should create a Github Release or use an existing draft
 create-release = false
 github-build-setup = "build-setup.yml"
 # The installers to generate for each app


### PR DESCRIPTION
This fixes the issue while creating a github release which is already created by release-plz.