### PR TITLE
feat: add EVM Provider and Tangle Client Context Extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,9 @@ dependencies = [
 name = "gadget-context-derive"
 version = "0.1.0"
 dependencies = [
+ "alloy-network",
+ "alloy-provider",
+ "alloy-transport",
  "gadget-sdk",
  "proc-macro2",
  "quote",

--- a/blueprint-manager/src/cli.rs
+++ b/blueprint-manager/src/cli.rs
@@ -6,35 +6,42 @@ use gadget_io::GadgetConfig;
 use sdk::entry;
 use structopt::StructOpt;
 
-#[tokio::main]
-async fn main() -> color_eyre::Result<()> {
-    color_eyre::install()?;
-    let blueprint_manager_config = BlueprintManagerConfig::from_args();
+fn main() -> color_eyre::Result<()> {
+    let body = async {
+        color_eyre::install()?;
+        let blueprint_manager_config = BlueprintManagerConfig::from_args();
 
-    entry::setup_blueprint_manager_logger(
-        blueprint_manager_config.verbose,
-        blueprint_manager_config.pretty,
-        "gadget",
-    )?;
+        entry::setup_blueprint_manager_logger(
+            blueprint_manager_config.verbose,
+            blueprint_manager_config.pretty,
+            "gadget",
+        )?;
 
-    if let Some(gadget_config) = blueprint_manager_config.gadget_config.as_ref() {
-        let gadget_config_settings = std::fs::read_to_string(gadget_config)?;
-        let gadget_config: GadgetConfig =
-            toml::from_str(&gadget_config_settings).map_err(|err| msg_to_error(err.to_string()))?;
+        if let Some(gadget_config) = blueprint_manager_config.gadget_config.as_ref() {
+            let gadget_config_settings = std::fs::read_to_string(gadget_config)?;
+            let gadget_config: GadgetConfig = toml::from_str(&gadget_config_settings)
+                .map_err(|err| msg_to_error(err.to_string()))?;
 
-        // Allow CTRL-C to shutdown this CLI application instance
-        let shutdown_signal = async move {
-            let _ = tokio::signal::ctrl_c().await;
-        };
+            // Allow CTRL-C to shutdown this CLI application instance
+            let shutdown_signal = async move {
+                let _ = tokio::signal::ctrl_c().await;
+            };
 
-        let handle =
-            run_blueprint_manager(blueprint_manager_config, gadget_config, shutdown_signal).await?;
+            let handle =
+                run_blueprint_manager(blueprint_manager_config, gadget_config, shutdown_signal)
+                    .await?;
 
-        handle.await
-    } else {
-        Err(msg_to_error(
-            "Gadget config file is required when running the blueprint manager in CLI mode"
-                .to_string(),
-        ))
-    }
+            handle.await
+        } else {
+            Err(msg_to_error(
+                "Gadget config file is required when running the blueprint manager in CLI mode"
+                    .to_string(),
+            ))
+        }
+    };
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed building the Runtime")
+        .block_on(body)
 }

--- a/macros/context-derive/Cargo.toml
+++ b/macros/context-derive/Cargo.toml
@@ -23,6 +23,10 @@ proc-macro2 = { workspace = true }
 [dev-dependencies]
 trybuild = { workspace = true }
 gadget-sdk = { workspace = true, features = ["std"] }
+# EVM Stuff
+alloy-network = { workspace = true }
+alloy-provider = { workspace = true }
+alloy-transport = { workspace = true }
 
 [features]
 default = ["std"]

--- a/macros/context-derive/src/cfg.rs
+++ b/macros/context-derive/src/cfg.rs
@@ -1,0 +1,56 @@
+use syn::{Data, Error, Fields, Ident, Index, Result};
+
+pub enum FieldInfo {
+    Named(Ident),
+    Unnamed(Index),
+}
+
+pub fn find_config_field(input_ident: &Ident, data: &Data) -> Result<FieldInfo> {
+    match data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => {
+                for field in &fields.named {
+                    if field
+                        .attrs
+                        .iter()
+                        .any(|attr| attr.path().is_ident("config"))
+                    {
+                        return field.ident.clone().map(FieldInfo::Named).ok_or_else(|| {
+                            Error::new_spanned(
+                                field,
+                                "Expected named field with #[config] attribute",
+                            )
+                        });
+                    }
+                }
+                Err(Error::new_spanned(
+                    input_ident,
+                    "No field with #[config] attribute found, please add #[config] to the field that holds the `gadget_sdk::config::GadgetConfiguration`",
+                ))
+            }
+            Fields::Unnamed(fields) => {
+                for (i, field) in fields.unnamed.iter().enumerate() {
+                    if field
+                        .attrs
+                        .iter()
+                        .any(|attr| attr.path().is_ident("config"))
+                    {
+                        return Ok(FieldInfo::Unnamed(Index::from(i)));
+                    }
+                }
+                Err(Error::new_spanned(
+                    input_ident,
+                    "No field with #[config] attribute found, please add #[config] to the field that holds the `gadget_sdk::config::GadgetConfiguration`",
+                ))
+            }
+            Fields::Unit => Err(Error::new_spanned(
+                input_ident,
+                "Context Extensions traits cannot be derived for unit structs",
+            )),
+        },
+        _ => Err(Error::new_spanned(
+            input_ident,
+            "Context Extensions traits can only be derived for structs",
+        )),
+    }
+}

--- a/macros/context-derive/src/evm.rs
+++ b/macros/context-derive/src/evm.rs
@@ -1,0 +1,45 @@
+use quote::quote;
+use syn::DeriveInput;
+
+use crate::cfg::FieldInfo;
+
+/// Generate the `EVMProviderContext` implementation for the given struct.
+pub fn generate_context_impl(
+    DeriveInput {
+        ident: name,
+        generics,
+        ..
+    }: DeriveInput,
+    config_field: FieldInfo,
+) -> proc_macro2::TokenStream {
+    let field_access = match config_field {
+        FieldInfo::Named(ident) => quote! { self.#ident },
+        FieldInfo::Unnamed(index) => quote! { self.#index },
+    };
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics gadget_sdk::ctx::EVMProviderContext for #name #ty_generics #where_clause {
+            type Network = alloy_network::Ethereum;
+            type Transport = alloy_transport::BoxTransport;
+            type Provider = alloy_provider::fillers::FillProvider<
+                alloy_provider::fillers::RecommendedFiller,
+                alloy_provider::RootProvider<Self::Transport>,
+                Self::Transport,
+                Self::Network,
+            >;
+            fn evm_provider(&self) -> impl core::future::Future<Output = Result<Self::Provider, alloy_transport::TransportError>> {
+                // TODO: think about caching the provider
+                async {
+                    let rpc_url = #field_access.rpc_endpoint.as_str();
+                    let provider = alloy_provider::ProviderBuilder::new()
+                        .with_recommended_fillers()
+                        .on_builtin(rpc_url)
+                        .await?;
+                    Ok(provider)
+                }
+            }
+        }
+    }
+}

--- a/macros/context-derive/src/evm.rs
+++ b/macros/context-derive/src/evm.rs
@@ -31,6 +31,7 @@ pub fn generate_context_impl(
             >;
             fn evm_provider(&self) -> impl core::future::Future<Output = Result<Self::Provider, alloy_transport::TransportError>> {
                 // TODO: think about caching the provider
+                // see: https://github.com/webb-tools/gadget/issues/320
                 async {
                     let rpc_url = #field_access.rpc_endpoint.as_str();
                     let provider = alloy_provider::ProviderBuilder::new()

--- a/macros/context-derive/src/keystore.rs
+++ b/macros/context-derive/src/keystore.rs
@@ -1,0 +1,46 @@
+use quote::quote;
+use syn::{parse_quote, DeriveInput};
+
+use crate::cfg::FieldInfo;
+
+/// Generate the `KeystoreContext` implementation for the given struct.
+pub fn generate_context_impl(
+    DeriveInput {
+        ident: name,
+        generics,
+        ..
+    }: DeriveInput,
+    config_field: FieldInfo,
+) -> proc_macro2::TokenStream {
+    let field_access = match config_field {
+        FieldInfo::Named(ident) => quote! { self.#ident },
+        FieldInfo::Unnamed(index) => quote! { self.#index },
+    };
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    // Create a new generics instance without the RwLock parameter
+    let mut generics_without_rwlock = generics.clone();
+    generics_without_rwlock
+        .params
+        .push(parse_quote!(RwLock: gadget_sdk::ext::lock_api::RawRwLock));
+
+    let (impl_generics_without_rwlock, _, where_clause_without_rwlock) =
+        generics_without_rwlock.split_for_impl();
+
+    quote! {
+        #[cfg(not(feature = "std"))]
+        impl #impl_generics_without_rwlock gadget_sdk::ctx::KeystoreContext<RwLock> for #name #ty_generics #where_clause_without_rwlock {
+            fn keystore(&self) -> Result<gadget_sdk::keystore::backend::GenericKeyStore<RwLock>, gadget_sdk::config::Error> {
+                #field_access.keystore()
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl #impl_generics gadget_sdk::ctx::KeystoreContext<gadget_sdk::ext::parking_lot::RawRwLock> for #name #ty_generics #where_clause {
+            fn keystore(&self) -> Result<gadget_sdk::keystore::backend::GenericKeyStore<gadget_sdk::ext::parking_lot::RawRwLock>, gadget_sdk::config::Error> {
+                #field_access.keystore()
+            }
+        }
+    }
+}

--- a/macros/context-derive/src/lib.rs
+++ b/macros/context-derive/src/lib.rs
@@ -10,15 +10,20 @@
 )]
 //! Proc-macros for deriving Context Extensions from [`gadget-sdk`](https://crates.io/crates/gadget-sdk) crate.
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Error, Fields, Ident, Index, Result};
+
+/// Field information for the configuration field.
+mod cfg;
+/// EVM Provider context extension implementation.
+mod evm;
+/// Keystore context extension implementation.
+mod keystore;
 
 /// Derive macro for generating Context Extensions trait implementation for `KeystoreContext`.
 #[proc_macro_derive(KeystoreContext, attributes(config))]
 pub fn derive_keystore_context(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let result = find_config_field(&input.ident, &input.data)
-        .map(|config_field| generate_keystore_context_impl(input, config_field));
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let result = cfg::find_config_field(&input.ident, &input.data)
+        .map(|config_field| keystore::generate_context_impl(input, config_field));
 
     match result {
         Ok(expanded) => TokenStream::from(expanded),
@@ -26,98 +31,15 @@ pub fn derive_keystore_context(input: TokenStream) -> TokenStream {
     }
 }
 
-enum FieldInfo {
-    Named(Ident),
-    Unnamed(Index),
-}
+/// Derive macro for generating Context Extensions trait implementation for `EVMProviderContext`.
+#[proc_macro_derive(EVMProviderContext, attributes(config))]
+pub fn derive_evm_provider_context(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let result = cfg::find_config_field(&input.ident, &input.data)
+        .map(|config_field| evm::generate_context_impl(input, config_field));
 
-fn find_config_field(input_ident: &Ident, data: &Data) -> Result<FieldInfo> {
-    match data {
-        Data::Struct(data_struct) => match &data_struct.fields {
-            Fields::Named(fields) => {
-                for field in &fields.named {
-                    if field
-                        .attrs
-                        .iter()
-                        .any(|attr| attr.path().is_ident("config"))
-                    {
-                        return field.ident.clone().map(FieldInfo::Named).ok_or_else(|| {
-                            Error::new_spanned(
-                                field,
-                                "Expected named field with #[config] attribute",
-                            )
-                        });
-                    }
-                }
-                Err(Error::new_spanned(
-                    input_ident,
-                    "No field with #[config] attribute found, please add #[config] to the field that holds the `gadget_sdk::config::GadgetConfiguration`",
-                ))
-            }
-            Fields::Unnamed(fields) => {
-                for (i, field) in fields.unnamed.iter().enumerate() {
-                    if field
-                        .attrs
-                        .iter()
-                        .any(|attr| attr.path().is_ident("config"))
-                    {
-                        return Ok(FieldInfo::Unnamed(Index::from(i)));
-                    }
-                }
-                Err(Error::new_spanned(
-                    input_ident,
-                    "No field with #[config] attribute found, please add #[config] to the field that holds the `gadget_sdk::config::GadgetConfiguration`",
-                ))
-            }
-            Fields::Unit => Err(Error::new_spanned(
-                input_ident,
-                "Context Extensions traits cannot be derived for unit structs",
-            )),
-        },
-        _ => Err(Error::new_spanned(
-            input_ident,
-            "Context Extensions traits can only be derived for structs",
-        )),
-    }
-}
-
-fn generate_keystore_context_impl(
-    DeriveInput {
-        ident: name,
-        generics,
-        ..
-    }: DeriveInput,
-    config_field: FieldInfo,
-) -> proc_macro2::TokenStream {
-    let field_access = match config_field {
-        FieldInfo::Named(ident) => quote! { self.#ident },
-        FieldInfo::Unnamed(index) => quote! { self.#index },
-    };
-
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    // Create a new generics instance without the RwLock parameter
-    let mut generics_without_rwlock = generics.clone();
-    generics_without_rwlock
-        .params
-        .push(parse_quote!(RwLock: gadget_sdk::ext::lock_api::RawRwLock));
-
-    let (impl_generics_without_rwlock, _, where_clause_without_rwlock) =
-        generics_without_rwlock.split_for_impl();
-
-    quote! {
-        #[cfg(not(feature = "std"))]
-        impl #impl_generics_without_rwlock gadget_sdk::ctx::KeystoreContext<RwLock> for #name #ty_generics #where_clause_without_rwlock {
-            fn keystore(&self) -> Result<gadget_sdk::keystore::backend::GenericKeyStore<RwLock>, gadget_sdk::config::Error> {
-                #field_access.keystore()
-            }
-        }
-
-        #[cfg(feature = "std")]
-        impl #impl_generics gadget_sdk::ctx::KeystoreContext<gadget_sdk::ext::parking_lot::RawRwLock> for #name #ty_generics #where_clause {
-            fn keystore(&self) -> Result<gadget_sdk::keystore::backend::GenericKeyStore<gadget_sdk::ext::parking_lot::RawRwLock>, gadget_sdk::config::Error> {
-                #field_access.keystore()
-            }
-        }
+    match result {
+        Ok(expanded) => TokenStream::from(expanded),
+        Err(err) => TokenStream::from(err.to_compile_error()),
     }
 }

--- a/macros/context-derive/src/lib.rs
+++ b/macros/context-derive/src/lib.rs
@@ -17,6 +17,8 @@ mod cfg;
 mod evm;
 /// Keystore context extension implementation.
 mod keystore;
+/// Tangle Subxt Client context extension implementation.
+mod subxt;
 
 /// Derive macro for generating Context Extensions trait implementation for `KeystoreContext`.
 #[proc_macro_derive(KeystoreContext, attributes(config))]
@@ -37,6 +39,19 @@ pub fn derive_evm_provider_context(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let result = cfg::find_config_field(&input.ident, &input.data)
         .map(|config_field| evm::generate_context_impl(input, config_field));
+
+    match result {
+        Ok(expanded) => TokenStream::from(expanded),
+        Err(err) => TokenStream::from(err.to_compile_error()),
+    }
+}
+
+/// Derive macro for generating Context Extensions trait implementation for `TangleClientContext`.
+#[proc_macro_derive(TangleClientContext, attributes(config))]
+pub fn derive_tangle_client_context(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let result = cfg::find_config_field(&input.ident, &input.data)
+        .map(|config_field| subxt::generate_context_impl(input, config_field));
 
     match result {
         Ok(expanded) => TokenStream::from(expanded),

--- a/macros/context-derive/src/subxt.rs
+++ b/macros/context-derive/src/subxt.rs
@@ -23,7 +23,8 @@ pub fn generate_context_impl(
         impl #impl_generics gadget_sdk::ctx::TangleClientContext for #name #ty_generics #where_clause {
             type Config = gadget_sdk::ext::subxt::PolkadotConfig;
             fn tangle_client(&self) -> impl core::future::Future<Output = Result<gadget_sdk::ext::subxt::OnlineClient<Self::Config>, gadget_sdk::ext::subxt::Error>> {
-                // TODO: think about caching the provider
+                // TODO: think about caching the client
+                // see: https://github.com/webb-tools/gadget/issues/320
                 async {
                     let rpc_url = #field_access.rpc_endpoint.as_str();
                     let client = gadget_sdk::ext::subxt::OnlineClient::from_url(rpc_url).await?;

--- a/macros/context-derive/src/subxt.rs
+++ b/macros/context-derive/src/subxt.rs
@@ -1,0 +1,35 @@
+use quote::quote;
+use syn::DeriveInput;
+
+use crate::cfg::FieldInfo;
+
+/// Generate the `TangleClientContext` implementation for the given struct.
+pub fn generate_context_impl(
+    DeriveInput {
+        ident: name,
+        generics,
+        ..
+    }: DeriveInput,
+    config_field: FieldInfo,
+) -> proc_macro2::TokenStream {
+    let field_access = match config_field {
+        FieldInfo::Named(ident) => quote! { self.#ident },
+        FieldInfo::Unnamed(index) => quote! { self.#index },
+    };
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics gadget_sdk::ctx::TangleClientContext for #name #ty_generics #where_clause {
+            type Config = gadget_sdk::ext::subxt::PolkadotConfig;
+            fn tangle_client(&self) -> impl core::future::Future<Output = Result<gadget_sdk::ext::subxt::OnlineClient<Self::Config>, gadget_sdk::ext::subxt::Error>> {
+                // TODO: think about caching the provider
+                async {
+                    let rpc_url = #field_access.rpc_endpoint.as_str();
+                    let client = gadget_sdk::ext::subxt::OnlineClient::from_url(rpc_url).await?;
+                    Ok(client)
+                }
+            }
+        }
+    }
+}

--- a/macros/context-derive/tests/tests.rs
+++ b/macros/context-derive/tests/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_derive_keystore_context() {
+    fn test_derive_context() {
         let t = trybuild::TestCases::new();
         t.pass("tests/ui/01_basic.rs");
         t.pass("tests/ui/02_unnamed_fields.rs");

--- a/macros/context-derive/tests/ui/01_basic.rs
+++ b/macros/context-derive/tests/ui/01_basic.rs
@@ -1,7 +1,7 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext};
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, TangleClientContext};
 
-#[derive(KeystoreContext, EVMProviderContext)]
+#[derive(KeystoreContext, EVMProviderContext, TangleClientContext)]
 struct MyContext {
     foo: String,
     #[config]
@@ -15,4 +15,5 @@ fn main() {
     };
     let _keystore = ctx.keystore();
     let _evm_provider = ctx.evm_provider();
+    let _tangle_client = ctx.tangle_client();
 }

--- a/macros/context-derive/tests/ui/01_basic.rs
+++ b/macros/context-derive/tests/ui/01_basic.rs
@@ -1,7 +1,7 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::KeystoreContext;
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext};
 
-#[derive(KeystoreContext)]
+#[derive(KeystoreContext, EVMProviderContext)]
 struct MyContext {
     foo: String,
     #[config]
@@ -14,4 +14,5 @@ fn main() {
         sdk_config: Default::default(),
     };
     let _keystore = ctx.keystore();
+    let _evm_provider = ctx.evm_provider();
 }

--- a/macros/context-derive/tests/ui/02_unnamed_fields.rs
+++ b/macros/context-derive/tests/ui/02_unnamed_fields.rs
@@ -1,10 +1,11 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::KeystoreContext;
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext};
 
-#[derive(KeystoreContext)]
+#[derive(KeystoreContext, EVMProviderContext)]
 struct MyContext(String, #[config] StdGadgetConfiguration);
 
 fn main() {
     let ctx = MyContext("bar".to_string(), Default::default());
     let _keystore = ctx.keystore();
+    let _evm_provider = ctx.evm_provider();
 }

--- a/macros/context-derive/tests/ui/02_unnamed_fields.rs
+++ b/macros/context-derive/tests/ui/02_unnamed_fields.rs
@@ -1,11 +1,12 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext};
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, TangleClientContext};
 
-#[derive(KeystoreContext, EVMProviderContext)]
+#[derive(KeystoreContext, EVMProviderContext, TangleClientContext)]
 struct MyContext(String, #[config] StdGadgetConfiguration);
 
 fn main() {
     let ctx = MyContext("bar".to_string(), Default::default());
     let _keystore = ctx.keystore();
     let _evm_provider = ctx.evm_provider();
+    let _tangle_client = ctx.tangle_client();
 }

--- a/macros/context-derive/tests/ui/03_generic_struct.rs
+++ b/macros/context-derive/tests/ui/03_generic_struct.rs
@@ -1,7 +1,7 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext};
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, TangleClientContext};
 
-#[derive(KeystoreContext, EVMProviderContext)]
+#[derive(KeystoreContext, EVMProviderContext, TangleClientContext)]
 struct MyContext<T, U> {
     foo: T,
     bar: U,
@@ -17,4 +17,5 @@ fn main() {
     };
     let _keystore = ctx.keystore();
     let _evm_provider = ctx.evm_provider();
+    let _tangle_client = ctx.tangle_client();
 }

--- a/macros/context-derive/tests/ui/03_generic_struct.rs
+++ b/macros/context-derive/tests/ui/03_generic_struct.rs
@@ -1,7 +1,7 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::KeystoreContext;
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext};
 
-#[derive(KeystoreContext)]
+#[derive(KeystoreContext, EVMProviderContext)]
 struct MyContext<T, U> {
     foo: T,
     bar: U,
@@ -16,4 +16,5 @@ fn main() {
         sdk_config: Default::default(),
     };
     let _keystore = ctx.keystore();
+    let _evm_provider = ctx.evm_provider();
 }

--- a/sdk/src/ctx.rs
+++ b/sdk/src/ctx.rs
@@ -32,6 +32,8 @@
 //! ```
 //!
 
+use core::future::Future;
+
 use crate::keystore::backend::GenericKeyStore;
 // derives
 pub use gadget_context_derive::*;
@@ -46,4 +48,15 @@ pub trait KeystoreContext<RwLock: lock_api::RawRwLock> {
 pub trait GossipNetworkContext {
     /// Get the Goossip client from the context.
     fn gossip_network(&self) -> &crate::network::gossip::GossipHandle;
+}
+
+/// `EVMProviderContext` trait provides access to the EVM provider from the context.
+pub trait EVMProviderContext {
+    type Network: alloy_network::Network;
+    type Transport: alloy_transport::Transport + Clone;
+    type Provider: alloy_provider::Provider<Self::Transport, Self::Network>;
+    /// Get the EVM provider from the context.
+    fn evm_provider(
+        &self,
+    ) -> impl Future<Output = Result<Self::Provider, alloy_transport::TransportError>>;
 }

--- a/sdk/src/ctx.rs
+++ b/sdk/src/ctx.rs
@@ -60,3 +60,12 @@ pub trait EVMProviderContext {
         &self,
     ) -> impl Future<Output = Result<Self::Provider, alloy_transport::TransportError>>;
 }
+
+/// `TangleClientContext` trait provides access to the Tangle client from the context.
+pub trait TangleClientContext {
+    type Config: subxt::Config;
+    /// Get the Tangle client from the context.
+    fn tangle_client(
+        &self,
+    ) -> impl Future<Output = Result<subxt::OnlineClient<Self::Config>, subxt::Error>>;
+}

--- a/sdk/src/executor/mod.rs
+++ b/sdk/src/executor/mod.rs
@@ -59,6 +59,7 @@ pub async fn run_executor(instructions: &str) {
     );
 }
 
+#[allow(unused_imports, clippy::needless_return)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -72,4 +72,6 @@ pub mod ext {
     pub use lock_api;
     #[cfg(feature = "std")]
     pub use parking_lot;
+    pub use tangle_subxt::subxt;
+    pub use tangle_subxt::subxt_signer;
 }

--- a/sdk/src/metrics/mod.rs
+++ b/sdk/src/metrics/mod.rs
@@ -137,7 +137,7 @@ async fn init_prometheus_with_listener(
 }
 
 #[cfg(test)]
-#[allow(clippy::let_underscore_future)]
+#[allow(clippy::let_underscore_future, clippy::needless_return)]
 mod tests {
     use super::*;
     use http_body_util::BodyExt;

--- a/sdk/src/store/mod.rs
+++ b/sdk/src/store/mod.rs
@@ -195,6 +195,7 @@ fn key_to_string(key: &[u8; 32]) -> String {
     hex::encode(key)
 }
 
+#[allow(clippy::needless_return)]
 #[cfg(test)]
 #[cfg(not(target_family = "wasm"))]
 mod tests {


### PR DESCRIPTION
This pull request introduces significant enhancements to the `macros/context-derive` crate by adding support for EVM and Tangle client contexts, refactoring existing code, and updating tests to cover new functionalities.

### New Features:
* Added dependencies for EVM-related functionality in `Cargo.toml`. (`macros/context-derive/Cargo.toml`)
* Introduced `EVMProviderContext` and `TangleClientContext` traits in the `gadget-sdk` crate. (`sdk/src/ctx.rs`)

### Code Refactoring:
* Split `cfg`, `evm`, `keystore`, and `subxt` modules into separate files for better modularity. (`macros/context-derive/src/lib.rs`)
* Refactored `find_config_field` function and `FieldInfo` enum into `cfg` module. (`macros/context-derive/src/cfg.rs`)

### New Implementations:
* Implemented `generate_context_impl` for `EVMProviderContext`. (`macros/context-derive/src/evm.rs`)
* Implemented `generate_context_impl` for `TangleClientContext`. (`macros/context-derive/src/subxt.rs`)

### Testing:
* Updated tests to include `EVMProviderContext` and `TangleClientContext` derivations. (`macros/context-derive/tests/ui/01_basic.rs`, `macros/context-derive/tests/ui/02_unnamed_fields.rs`, `macros/context-derive/tests/ui/03_generic_struct.rs`) [[1]](diffhunk://#diff-979ee913599319cc2257ecd5a68a0ee31df0c57c63bee4dd63c4136fafc68669L2-R4) [[2]](diffhunk://#diff-39373db8178c9283c11482e8d42978eee0e70b5ca69cdb0b895405b1609c37c0L2-R11) [[3]](diffhunk://#diff-386067785bcc74d3c080001e15f96edd94afc9ad8f42ead62266bf9e4517d4ceL2-R4)

### Dependency Updates:
* Added necessary imports for new traits and future support in `gadget-sdk`. (`sdk/src/lib.rs`)

These changes collectively enhance the functionality and maintainability of the codebase, providing robust support for EVM and Tangle client contexts.

Part of #265 