### PR TITLE
feat: add ServicesContext Extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         package: [
           gadget-sdk,
           blueprint-manager,
+          gadget-context-derive,
         ]
     steps:
       - name: checkout code

--- a/macros/context-derive/src/lib.rs
+++ b/macros/context-derive/src/lib.rs
@@ -17,6 +17,8 @@ mod cfg;
 mod evm;
 /// Keystore context extension implementation.
 mod keystore;
+/// Services context extension implementation.
+mod services;
 /// Tangle Subxt Client context extension implementation.
 mod subxt;
 
@@ -52,6 +54,19 @@ pub fn derive_tangle_client_context(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let result = cfg::find_config_field(&input.ident, &input.data)
         .map(|config_field| subxt::generate_context_impl(input, config_field));
+
+    match result {
+        Ok(expanded) => TokenStream::from(expanded),
+        Err(err) => TokenStream::from(err.to_compile_error()),
+    }
+}
+
+/// Derive macro for generating Context Extensions trait implementation for `ServicesContext`.
+#[proc_macro_derive(ServicesContext, attributes(config))]
+pub fn derive_services_context(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let result = cfg::find_config_field(&input.ident, &input.data)
+        .map(|config_field| services::generate_context_impl(input, config_field));
 
     match result {
         Ok(expanded) => TokenStream::from(expanded),

--- a/macros/context-derive/src/services.rs
+++ b/macros/context-derive/src/services.rs
@@ -1,0 +1,101 @@
+use quote::quote;
+use syn::DeriveInput;
+
+use crate::cfg::FieldInfo;
+
+/// Generate the `ServicesContext` implementation for the given struct.
+pub fn generate_context_impl(
+    DeriveInput {
+        ident: name,
+        generics,
+        ..
+    }: DeriveInput,
+    config_field: FieldInfo,
+) -> proc_macro2::TokenStream {
+    let field_access = match config_field {
+        FieldInfo::Named(ident) => quote! { self.#ident },
+        FieldInfo::Unnamed(index) => quote! { self.#index },
+    };
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics gadget_sdk::ctx::ServicesContext for #name #ty_generics #where_clause {
+            type Config = gadget_sdk::ext::subxt::PolkadotConfig;
+            /// Get the current blueprint information from the context.
+            fn current_blueprint(
+                &self,
+                client: &gadget_sdk::ext::subxt::OnlineClient<Self::Config>,
+            ) -> impl core::future::Future<
+                Output = Result<
+                    gadget_sdk::ext::tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::ServiceBlueprint,
+                    gadget_sdk::ext::subxt::Error
+                >
+            > {
+                use gadget_sdk::ext::tangle_subxt::tangle_testnet_runtime::api;
+                use gadget_sdk::ext::subxt;
+
+                async move {
+                    let blueprint_id = #field_access.blueprint_id;
+                    let blueprint = api::storage().services().blueprints(blueprint_id);
+                    let storage = client.storage().at_latest().await?;
+                    let result = storage.fetch(&blueprint).await?;
+                    match result {
+                        Some((_, blueprint)) => Ok(blueprint),
+                        None => Err(subxt::Error::Other(format!(
+                            "Blueprint with id {blueprint_id} not found"
+                        ))),
+                    }
+                }
+            }
+
+            /// Query the current blueprint owner from the context.
+            fn current_blueprint_owner(
+                &self,
+                client: &gadget_sdk::ext::subxt::OnlineClient<Self::Config>,
+            ) -> impl core::future::Future<Output = Result<gadget_sdk::ext::subxt::utils::AccountId32, gadget_sdk::ext::subxt::Error>> {
+                use gadget_sdk::ext::tangle_subxt::tangle_testnet_runtime::api;
+                use gadget_sdk::ext::subxt;
+                async move {
+                    let blueprint_id = #field_access.blueprint_id;
+                    let blueprint = api::storage().services().blueprints(blueprint_id);
+                    let storage = client.storage().at_latest().await?;
+                    let result = storage.fetch(&blueprint).await?;
+                    match result {
+                        Some((account_id, _)) => Ok(account_id),
+                        None => Err(subxt::Error::Other(format!(
+                            "Blueprint with id {blueprint_id} not found"
+                        ))),
+                    }
+                }
+            }
+
+            /// Get the current service operators from the context.
+            /// This function will return a list of service operators that are selected to run this service
+            /// instance.
+            fn current_service_operators(
+                &self,
+                client: &gadget_sdk::ext::subxt::OnlineClient<Self::Config>,
+            ) -> impl core::future::Future<Output = Result<Vec<gadget_sdk::ext::subxt::utils::AccountId32>, gadget_sdk::ext::subxt::Error>> {
+                use gadget_sdk::ext::tangle_subxt::tangle_testnet_runtime::api;
+                use gadget_sdk::ext::subxt;
+
+                async move {
+                    let service_instance_id = match #field_access.service_id {
+                        Some(service_id) => service_id,
+                        None => return Err(subxt::Error::Other("Service instance id is not set".to_string())),
+                    };
+                    let service_instance = api::storage().services().instances(service_instance_id);
+                    let storage = client.storage().at_latest().await?;
+                    let result = storage.fetch(&service_instance).await?;
+                    match result {
+                        Some(instance) => Ok(instance.operators.0),
+                        None => Err(subxt::Error::Other(format!(
+                            "Service instance {service_instance_id} is not created, yet"
+                        ))),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/macros/context-derive/tests/ui/01_basic.rs
+++ b/macros/context-derive/tests/ui/01_basic.rs
@@ -1,7 +1,7 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, TangleClientContext};
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, ServicesContext, TangleClientContext};
 
-#[derive(KeystoreContext, EVMProviderContext, TangleClientContext)]
+#[derive(KeystoreContext, EVMProviderContext, TangleClientContext, ServicesContext)]
 struct MyContext {
     foo: String,
     #[config]
@@ -9,11 +9,17 @@ struct MyContext {
 }
 
 fn main() {
-    let ctx = MyContext {
-        foo: "bar".to_string(),
-        sdk_config: Default::default(),
+    let body = async {
+        let ctx = MyContext {
+            foo: "bar".to_string(),
+            sdk_config: Default::default(),
+        };
+        let _keystore = ctx.keystore();
+        let _evm_provider = ctx.evm_provider().await;
+        let tangle_client = ctx.tangle_client().await.unwrap();
+        let _services = ctx.current_service_operators(&tangle_client).await.unwrap();
     };
-    let _keystore = ctx.keystore();
-    let _evm_provider = ctx.evm_provider();
-    let _tangle_client = ctx.tangle_client();
+
+    // Run the async block
+    let _ = body;
 }

--- a/macros/context-derive/tests/ui/02_unnamed_fields.rs
+++ b/macros/context-derive/tests/ui/02_unnamed_fields.rs
@@ -1,12 +1,17 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, TangleClientContext};
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, ServicesContext, TangleClientContext};
 
-#[derive(KeystoreContext, EVMProviderContext, TangleClientContext)]
+#[derive(KeystoreContext, EVMProviderContext, TangleClientContext, ServicesContext)]
 struct MyContext(String, #[config] StdGadgetConfiguration);
 
 fn main() {
-    let ctx = MyContext("bar".to_string(), Default::default());
-    let _keystore = ctx.keystore();
-    let _evm_provider = ctx.evm_provider();
-    let _tangle_client = ctx.tangle_client();
+    let body = async {
+        let ctx = MyContext("bar".to_string(), Default::default());
+        let _keystore = ctx.keystore();
+        let _evm_provider = ctx.evm_provider().await;
+        let tangle_client = ctx.tangle_client().await.unwrap();
+        let _services = ctx.current_service_operators(&tangle_client).await;
+    };
+    // Run the async block
+    let _ = body;
 }

--- a/macros/context-derive/tests/ui/03_generic_struct.rs
+++ b/macros/context-derive/tests/ui/03_generic_struct.rs
@@ -1,7 +1,7 @@
 use gadget_sdk::config::StdGadgetConfiguration;
-use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, TangleClientContext};
+use gadget_sdk::ctx::{EVMProviderContext, KeystoreContext, ServicesContext, TangleClientContext};
 
-#[derive(KeystoreContext, EVMProviderContext, TangleClientContext)]
+#[derive(KeystoreContext, EVMProviderContext, TangleClientContext, ServicesContext)]
 struct MyContext<T, U> {
     foo: T,
     bar: U,
@@ -10,12 +10,18 @@ struct MyContext<T, U> {
 }
 
 fn main() {
-    let ctx = MyContext {
-        foo: "bar".to_string(),
-        bar: 42,
-        sdk_config: Default::default(),
+    let body = async {
+        let ctx = MyContext {
+            foo: "bar".to_string(),
+            bar: 42,
+            sdk_config: Default::default(),
+        };
+        let _keystore = ctx.keystore();
+        let _evm_provider = ctx.evm_provider().await.unwrap();
+        let tangle_client = ctx.tangle_client().await.unwrap();
+        let _services = ctx.current_service_operators(&tangle_client).await.unwrap();
     };
-    let _keystore = ctx.keystore();
-    let _evm_provider = ctx.evm_provider();
-    let _tangle_client = ctx.tangle_client();
+
+    // Run the async block
+    let _ = body;
 }

--- a/sdk/src/ctx.rs
+++ b/sdk/src/ctx.rs
@@ -37,6 +37,7 @@ use core::future::Future;
 use crate::keystore::backend::GenericKeyStore;
 // derives
 pub use gadget_context_derive::*;
+use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::ServiceBlueprint;
 
 /// `KeystoreContext` trait provides access to the generic keystore from the context.
 pub trait KeystoreContext<RwLock: lock_api::RawRwLock> {
@@ -68,4 +69,28 @@ pub trait TangleClientContext {
     fn tangle_client(
         &self,
     ) -> impl Future<Output = Result<subxt::OnlineClient<Self::Config>, subxt::Error>>;
+}
+
+/// `ServicesContext` trait provides access to the current service and current blueprint from the context.
+pub trait ServicesContext {
+    type Config: subxt::Config;
+    /// Get the current blueprint information from the context.
+    fn current_blueprint(
+        &self,
+        client: &subxt::OnlineClient<Self::Config>,
+    ) -> impl Future<Output = Result<ServiceBlueprint, subxt::Error>>;
+
+    /// Query the current blueprint owner from the context.
+    fn current_blueprint_owner(
+        &self,
+        client: &subxt::OnlineClient<Self::Config>,
+    ) -> impl Future<Output = Result<subxt::utils::AccountId32, subxt::Error>>;
+
+    /// Get the current service operators from the context.
+    /// This function will return a list of service operators that are selected to run this service
+    /// instance.
+    fn current_service_operators(
+        &self,
+        client: &subxt::OnlineClient<Self::Config>,
+    ) -> impl Future<Output = Result<Vec<subxt::utils::AccountId32>, subxt::Error>>;
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -72,6 +72,7 @@ pub mod ext {
     pub use lock_api;
     #[cfg(feature = "std")]
     pub use parking_lot;
+    pub use tangle_subxt;
     pub use tangle_subxt::subxt;
     pub use tangle_subxt::subxt_signer;
 }


### PR DESCRIPTION
This pull request introduces a new `ServicesContext` trait and its corresponding derive macro to the `context-derive` crate, along with updates to existing test files to incorporate this new trait. The most important changes include adding the `ServicesContext` module, implementing the derive macro, generating the context implementation, and updating the test cases to use the new trait.

### New `ServicesContext` Trait and Derive Macro:

* [`macros/context-derive/src/lib.rs`](diffhunk://#diff-20cccca6733ac2e3b3a8c7b201c2947890985b62696cba77ce377b45fd66dc8eR20-R21): Added the `services` module and implemented the `derive_services_context` function to generate the `ServicesContext` trait implementation. [[1]](diffhunk://#diff-20cccca6733ac2e3b3a8c7b201c2947890985b62696cba77ce377b45fd66dc8eR20-R21) [[2]](diffhunk://#diff-20cccca6733ac2e3b3a8c7b201c2947890985b62696cba77ce377b45fd66dc8eR63-R75)
* [`macros/context-derive/src/services.rs`](diffhunk://#diff-49947b611433463ed6c702355c15df16f14f0726bd04dcd4f1d753f6764e70a1R1-R101): Implemented the `generate_context_impl` function to generate the `ServicesContext` implementation for the given struct.

### Test Updates:

* [`macros/context-derive/tests/ui/01_basic.rs`](diffhunk://#diff-979ee913599319cc2257ecd5a68a0ee31df0c57c63bee4dd63c4136fafc68669L2-R24): Updated to derive `ServicesContext` and added async block to test the new trait methods.
* [`macros/context-derive/tests/ui/02_unnamed_fields.rs`](diffhunk://#diff-39373db8178c9283c11482e8d42978eee0e70b5ca69cdb0b895405b1609c37c0L2-R16): Updated to derive `ServicesContext` and added async block to test the new trait methods.
* [`macros/context-derive/tests/ui/03_generic_struct.rs`](diffhunk://#diff-386067785bcc74d3c080001e15f96edd94afc9ad8f42ead62266bf9e4517d4ceL2-R4): Updated to derive `ServicesContext` and added async block to test the new trait methods. [[1]](diffhunk://#diff-386067785bcc74d3c080001e15f96edd94afc9ad8f42ead62266bf9e4517d4ceL2-R4) [[2]](diffhunk://#diff-386067785bcc74d3c080001e15f96edd94afc9ad8f42ead62266bf9e4517d4ceR13-R26)

### SDK Integration:

* [`sdk/src/ctx.rs`](diffhunk://#diff-112deb6dbc29dcc3eaca4a1c330e412ebc04b1e77087e7228c89cfd6aa75ca3aR73-R96): Added the `ServicesContext` trait definition and its methods.
* [`sdk/src/lib.rs`](diffhunk://#diff-d8b2bc9f3303d943e5be413a2c54965e6faa5836ccd597d12fa2a557df826608R75): Exported necessary modules for `ServicesContext`.

Part of #265 