### PR TITLE
chore: add CLI description to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ gadget-blueprint-proc-macro = { path = "./macros/blueprint-proc-macro", default-
 gadget-blueprint-proc-macro-core = { path = "./macros/blueprint-proc-macro-core", default-features = false, version = "0.1.2" }
 gadget-context-derive = { path = "./macros/context-derive", default-features = false, version = "0.1.0" }
 blueprint-metadata = { path = "./blueprint-metadata", default-features = false, version = "0.1.2" }
-cargo-tangle = { path = "./cli", version = "0.1.1-beta.7" }
+cargo-tangle = { path = "./cli", version = "0.1.2" }
 cargo_metadata = { version = "0.18.1" }
 
 # Tangle-related dependencies

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-tangle"
 version = "0.1.2"
-description = "a command-line tool to create and deploy blueprints on Tangle Network"
+description = "A command-line tool to create and deploy blueprints on Tangle Network"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cargo-tangle"
-version = "0.1.1-beta.7"
+version = "0.1.2"
+description = "a command-line tool to create and deploy blueprints on Tangle Network"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
fix the issue where the CLI package does not have description, which prevents it from being published.