### PR TITLE
feat: allow env vars for `ContextConfig` args

### DIFF
--- a/sdk/src/config.rs
+++ b/sdk/src/config.rs
@@ -234,10 +234,10 @@ pub enum GadgetCLICoreSettings {
         test_mode: bool,
         #[structopt(long, short = "l", env)]
         log_id: Option<String>,
-        #[structopt(long, short = "u", long = "url", parse(try_from_str = url::Url::parse), env)]
+        #[structopt(long, short = "u", parse(try_from_str = url::Url::parse), env)]
         #[serde(default = "gadget_io::defaults::rpc_url")]
         url: Url,
-        #[structopt(long = "bootnodes", parse(try_from_str = <Multiaddr as std::str::FromStr>::from_str))]
+        #[structopt(long, parse(try_from_str = <Multiaddr as std::str::FromStr>::from_str))]
         #[serde(default)]
         bootnodes: Option<Vec<Multiaddr>>,
         #[structopt(long, short = "d", env)]
@@ -259,7 +259,7 @@ pub enum GadgetCLICoreSettings {
         /// Whether to use pretty logging
         #[structopt(long)]
         pretty: bool,
-        #[structopt(long = "keystore-password", env)]
+        #[structopt(long, env)]
         keystore_password: Option<String>,
         #[structopt(long, env)]
         blueprint_id: u64,

--- a/sdk/src/config.rs
+++ b/sdk/src/config.rs
@@ -226,21 +226,21 @@ pub struct ContextConfig {
 pub enum GadgetCLICoreSettings {
     #[structopt(name = "run")]
     Run {
-        #[structopt(long, short = "b", parse(try_from_str))]
+        #[structopt(long, short = "b", parse(try_from_str), env)]
         bind_addr: IpAddr,
-        #[structopt(long, short = "p")]
+        #[structopt(long, short = "p", env)]
         bind_port: u16,
-        #[structopt(long, short = "t")]
+        #[structopt(long, short = "t", env)]
         test_mode: bool,
-        #[structopt(long, short = "l")]
+        #[structopt(long, short = "l", env)]
         log_id: Option<String>,
-        #[structopt(long, short = "u", long = "url", parse(try_from_str = url::Url::parse))]
+        #[structopt(long, short = "u", long = "url", parse(try_from_str = url::Url::parse), env)]
         #[serde(default = "gadget_io::defaults::rpc_url")]
         url: Url,
         #[structopt(long = "bootnodes", parse(try_from_str = <Multiaddr as std::str::FromStr>::from_str))]
         #[serde(default)]
         bootnodes: Option<Vec<Multiaddr>>,
-        #[structopt(long, short = "d")]
+        #[structopt(long, short = "d", env)]
         keystore_uri: String,
         #[structopt(
             long,
@@ -250,7 +250,8 @@ pub enum GadgetCLICoreSettings {
                 "local_mainnet",
                 "testnet",
                 "mainnet"
-            ]
+            ],
+            env
         )]
         chain: SupportedChains,
         #[structopt(long, short = "v", parse(from_occurrences))]
@@ -260,11 +261,11 @@ pub enum GadgetCLICoreSettings {
         pretty: bool,
         #[structopt(long = "keystore-password", env)]
         keystore_password: Option<String>,
-        #[structopt(long)]
+        #[structopt(long, env)]
         blueprint_id: u64,
-        #[structopt(long)]
+        #[structopt(long, env)]
         service_id: Option<u64>,
-        #[structopt(long, parse(try_from_str))]
+        #[structopt(long, parse(try_from_str), env)]
         protocol: Protocol,
     },
 }


### PR DESCRIPTION
Since the blueprint template now supports generating `Dockerfile`s, this makes it a little simpler.

For now, the blueprint template uses an entrypoint script to use env vars as arguments: https://github.com/webb-tools/blueprint-template/blob/main/docker/entrypoint.sh

This makes it possible to just have the binary as the entrypoint without having to rebuild the image when changing arguments.